### PR TITLE
fix: address framework issues from first session

### DIFF
--- a/.claude/framework/hooks/branch-safety.sh
+++ b/.claude/framework/hooks/branch-safety.sh
@@ -6,7 +6,7 @@ source "$SCRIPT_DIR/_helpers.sh" 2>/dev/null || exit 1
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
-echo "$COMMAND" | grep -qE '^\s*git\s+push' || exit 0
+echo "$COMMAND" | grep -qE '(git\s+push|gh\s+repo\s+create\s.*--push|gh\s+pr\s+merge)' || exit 0
 
 BRANCH=$(get_branch)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ At the start of every new session, before any other work:
 - Follow the Builder's Guide phases in sequence (Phase 0 → 1 → 2 → 3 → 4).
 - Reference the Platform Module for platform-specific architecture, tooling, testing, and distribution.
 - Every phase produces artifacts that gate entry into the next phase. Do not skip ahead.
+- **When executing numbered steps within a phase, complete them in order.** Do not infer completion from local state — verify each step explicitly. "The local repo exists" does not mean "the remote repo was created and branch protection was configured."
 
 ### Governance Tracking
 - The Approval Log (`APPROVAL_LOG.md`) records all phase gate approvals.

--- a/docs/framework/builders-guide.md
+++ b/docs/framework/builders-guide.md
@@ -793,6 +793,8 @@ Direct the agent to generate the CI configuration:
 > **⟁ PLATFORM MODULE:** Reference your Platform Module for platform-specific CI steps: cross-platform build matrix, code signing, packaging verification, platform-specific test runners.
 
 **7. Verify before building the first feature:**
+- [ ] Remote repository exists and is accessible (push a test commit if needed)
+- [ ] Branch protection is configured on main (PRs required, status checks required, force push disabled)
 - [ ] Linter runs clean
 - [ ] Test runner executes (0 tests, 0 failures)
 - [ ] Initial data model applies successfully

--- a/docs/platform-modules/desktop.md
+++ b/docs/platform-modules/desktop.md
@@ -197,7 +197,13 @@ Unsigned applications trigger security warnings on Windows (SmartScreen) and mac
 
 **CI integration:** Code signing should happen in CI, not on the developer's machine. Store signing certificates as CI secrets.
 
-### 3.4 Binary Size Optimization
+### 3.4 Packaging Pitfalls
+
+**Nuitka + large native packages (VTK, Open3D, scipy):** `--include-package` and `--include-package-data` can cause infinite dependency analysis loops for packages with hundreds of compiled C++ modules. Use targeted `--include-module` flags for specific modules your code actually imports. Validate packaging as the **first Phase 2 task** — before writing any feature code.
+
+**Python version selection:** Do not use the latest Python release. Use the latest **stable** release that is fully supported by your entire dependency chain. Check compatibility of your UI framework (PySide6/PyQt), native packages (VTK, Open3D), and packaging tool (Nuitka, PyInstaller) **before** creating the venv. Bleeding-edge Python versions frequently lack wheel support for compiled packages and may have incompatible C API changes that break packaging tools. As a rule of thumb, use the Python version one minor release behind the latest (e.g., if 3.14 is latest, use 3.13).
+
+### 3.5 Binary Size Optimization
 
 | Framework | Typical Size | Optimization |
 |---|---|---|

--- a/tests/test_branch_safety_hook.sh
+++ b/tests/test_branch_safety_hook.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regression test for branch-safety.sh — verifies the hook catches
+# gh CLI commands that push to protected branches, not just git push.
+#
+# Run: bash tests/test_branch_safety_hook.sh
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")/../.claude/framework/hooks" && pwd)/branch-safety.sh"
+PASS=0
+FAIL=0
+
+check() {
+  local description="$1" command="$2" expected_exit="$3"
+  local input actual_exit
+  input=$(printf '{"tool_input":{"command":"%s"}}' "$command")
+
+  set +e
+  echo "$input" | CLAUDE_PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)" bash "$HOOK" 2>/dev/null
+  actual_exit=$?
+  set -e
+
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo "  PASS: $description (exit $actual_exit)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description (expected exit $expected_exit, got $actual_exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== branch-safety.sh regression tests ==="
+echo ""
+echo "Pattern matching (should be detected as push commands):"
+check "git push" "git push origin main" 0
+check "gh repo create --push" "gh repo create org/repo --public --source=. --push" 0
+check "gh pr merge" "gh pr merge 42" 0
+
+echo ""
+echo "Pattern matching (should NOT be detected as push commands):"
+check "git status" "git status" 0
+check "git commit" "git commit -m test" 0
+check "gh pr create" "gh pr create --title test" 0
+check "echo push" "echo push" 0
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Expand `branch-safety.sh` to catch `gh repo create --push` and `gh pr merge` bypassing branch protection
- Add step-sequencing instruction to CLAUDE.md — don't infer completion from local state
- Add remote repo + branch protection to Builder's Guide init checklist
- Document Nuitka + VTK packaging hang and Python version compatibility in Desktop Platform Module

## Test plan
- [ ] Verify `branch-safety.sh` blocks `gh repo create --push` on protected branches
- [ ] Verify lint/type-check pass on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)