### PR TITLE
fix: keyboard focus for info panel section headers (UAT 2)

### DIFF
--- a/src/meshscope/ui/info_panel.py
+++ b/src/meshscope/ui/info_panel.py
@@ -69,7 +69,13 @@ class CollapsibleSection(QWidget):
         # Header button
         self._header = QPushButton()
         self._header.setFlat(True)
-        self._header.setFocusPolicy(Qt.FocusPolicy.TabFocus)
+        self._header.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        self._header.setStyleSheet(
+            "QPushButton:focus { border: 2px solid #4a9eff; outline: none; }"
+            "QPushButton {"
+            " text-align: left; padding: 8px 10px; border: 2px solid transparent;"
+            " }"
+        )
         self._header.clicked.connect(self.toggle)
         self._update_header_text()
         layout.addWidget(self._header)
@@ -129,6 +135,7 @@ class InfoPanel(QDockWidget):
         self._scroll = QScrollArea()
         self._scroll.setWidgetResizable(True)
         self._scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        self._scroll.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.setWidget(self._scroll)
 
         # Main content widget

--- a/tests/ui/test_info_panel.py
+++ b/tests/ui/test_info_panel.py
@@ -298,4 +298,4 @@ class TestInfoPanelAccessibility:
             panel._dimensions_section,
             panel._status_section,
         ):
-            assert section.header_button.focusPolicy() == Qt.FocusPolicy.TabFocus
+            assert section.header_button.focusPolicy() == Qt.FocusPolicy.StrongFocus


### PR DESCRIPTION
## Summary
- Fix keyboard navigation in info panel collapsible sections (UAT2-001)
- Change focus policy from TabFocus to StrongFocus on section header buttons
- Add visible focus indicator (2px blue border) on keyboard focus
- Prevent QScrollArea from intercepting Tab key

## Test Plan
- [x] 225 tests passing
- [x] Manual retest: Tab reaches section headers, Enter/Space toggles, blue focus border visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)