### PR TITLE
fix: resolve 3 UAT3 bugs (custom dialog, bed persistence, highlight checkbox)

### DIFF
--- a/src/meshscope/ui/info_panel.py
+++ b/src/meshscope/ui/info_panel.py
@@ -462,7 +462,7 @@ class InfoPanel(QDockWidget):
                 f"{_WARNING} Degenerate faces: {analysis.degenerate_face_count}"
             )
 
-        # Auto-check highlight if any issues found
+        # Auto-check highlight if any issues found; hide checkbox when none
         has_issues = (
             not analysis.is_watertight
             or analysis.hole_count > 0
@@ -471,6 +471,7 @@ class InfoPanel(QDockWidget):
             or analysis.degenerate_face_count > 0
         )
         self._highlight_checkbox.setChecked(has_issues)
+        self._highlight_checkbox.setVisible(has_issues)
 
         self._analysis_section.setVisible(True)
 

--- a/src/meshscope/ui/main_window.py
+++ b/src/meshscope/ui/main_window.py
@@ -216,7 +216,7 @@ class MainWindow(QMainWindow):
             if self.bed_preset_combo.itemData(i) == saved_preset:
                 self.bed_preset_combo.setCurrentIndex(i)
                 break
-        self.bed_preset_combo.currentIndexChanged.connect(self._on_bed_preset_changed)
+        self.bed_preset_combo.activated.connect(self._on_bed_preset_changed)
         self.toolbar.addWidget(self.bed_preset_combo)
 
         self.toolbar.addSeparator()
@@ -301,8 +301,6 @@ class MainWindow(QMainWindow):
         self.bed_action.setEnabled(enabled)
         self.bed_preset_combo.setEnabled(enabled)
         self.analyze_action.setEnabled(enabled)
-        if not enabled:
-            self.bed_action.setChecked(False)
 
     # --- Toolbar callbacks ---
 

--- a/tests/ui/test_info_panel.py
+++ b/tests/ui/test_info_panel.py
@@ -377,3 +377,22 @@ class TestInfoPanelAnalysisSection:
     def test_has_highlight_checkbox(self, qapp: QApplication) -> None:
         panel = InfoPanel()
         assert panel.has_highlight_checkbox() is True
+
+    # UAT3-003 regression: checkbox must be hidden when analysis has no issues
+    def test_highlight_checkbox_hidden_when_no_issues(self, qapp: QApplication) -> None:
+        """UAT3-003: highlight checkbox must be hidden when analysis is clean."""
+        panel = InfoPanel()
+        panel.show_analysis(_make_clean_analysis())
+        assert panel._highlight_checkbox.isHidden(), (
+            "UAT3-003: checkbox must be hidden when has_issues is False."
+        )
+
+    def test_highlight_checkbox_visible_when_issues_exist(
+        self, qapp: QApplication
+    ) -> None:
+        """UAT3-003: highlight checkbox must be visible when there are issues."""
+        panel = InfoPanel()
+        panel.show_analysis(_make_problem_analysis())
+        assert not panel._highlight_checkbox.isHidden(), (
+            "UAT3-003: checkbox must be visible when analysis has issues."
+        )

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -373,3 +373,71 @@ class TestMainWindowAnalyze:
         window.analyze_action.trigger()  # second call must not raise
         assert window._document is not None
         assert window._document.analysis is not None
+
+
+class TestUAT3Regressions:
+    """Regression tests for UAT session 3 bugs."""
+
+    # UAT3-001: bed preset combo should use activated signal so re-selecting
+    # "Custom..." when already on Custom still reopens the dialog.
+    def test_bed_preset_combo_activated_fires_handler(self, window: MainWindow) -> None:
+        """UAT3-001: activated signal must invoke _on_bed_preset_changed."""
+        from unittest.mock import patch
+
+        combo = window.bed_preset_combo
+        call_count: list[int] = []
+
+        def recording_handler(index: int) -> None:
+            call_count.append(index)
+
+        with patch.object(
+            window, "_on_bed_preset_changed", side_effect=recording_handler
+        ):
+            combo.activated.emit(0)
+
+        assert len(call_count) == 1, (
+            "UAT3-001: bed_preset_combo 'activated' signal must be connected to "
+            "_on_bed_preset_changed. Emitting activated did not invoke the handler."
+        )
+
+    def test_bed_preset_combo_currentIndexChanged_not_connected(
+        self, window: MainWindow
+    ) -> None:
+        """UAT3-001: currentIndexChanged must NOT invoke _on_bed_preset_changed."""
+        from unittest.mock import patch
+
+        combo = window.bed_preset_combo
+        call_count: list[int] = []
+
+        def spy(index: int) -> None:
+            call_count.append(index)
+
+        with patch.object(window, "_on_bed_preset_changed", side_effect=spy):
+            # setCurrentIndex fires currentIndexChanged but NOT activated
+            original_index = combo.currentIndex()
+            new_index = 1 if original_index != 1 else 0
+            combo.setCurrentIndex(new_index)
+
+        assert len(call_count) == 0, (
+            "UAT3-001: currentIndexChanged must NOT be connected to "
+            "_on_bed_preset_changed. Use activated signal instead."
+        )
+
+    # UAT3-002: bed checked state must survive a file reload
+    def test_bed_stays_checked_after_reload(
+        self, window: MainWindow, tmp_path: Path
+    ) -> None:
+        """UAT3-002: bed must remain checked after loading a new file."""
+        fixtures = Path(__file__).parent.parent / "fixtures" / "valid"
+        window._load_file(fixtures / "cube.stl")
+
+        window.bed_action.setChecked(True)
+        assert window.bed_action.isChecked(), "Pre-condition: bed should be checked"
+
+        # Load the same file again — this used to uncheck the bed
+        window._load_file(fixtures / "cube.stl")
+
+        assert window.bed_action.isChecked(), (
+            "UAT3-002: bed_action must remain checked after a new file load. "
+            "_set_render_actions_enabled must not call bed_action.setChecked(False)."
+        )


### PR DESCRIPTION
## Summary
- Fix custom bed dialog not reopening when already on Custom (use `activated` signal instead of `currentIndexChanged`)
- Fix bed disappearing on new file load (preserve checked state across enable/disable cycle)
- Fix highlight checkbox visible when analysis finds no issues (add `setVisible(has_issues)`)

## Test Plan
- [x] 318 tests passing (5 new regression tests)
- [x] Manual retest of all 3 scenarios confirmed fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)