### PR TITLE
feat: add Cross-Section Slice Plane (Feature 10) + Measurement Tool fixes (Feature 9)

### DIFF
--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -7,13 +7,16 @@
     "print-bed-visualization",
     "manifold-watertight-check",
     "basic-mesh-repair",
-    "scale-rotate-mirror"
+    "scale-rotate-mirror",
+    "measurement-tool",
+    "cross-section-slice-plane"
   ],
-  "features_since_last_test": 0,
+  "features_since_last_test": 2,
   "test_interval": 2,
   "last_test_session": "2026-04-08",
-  "testing_required": false,
+  "testing_required": true,
   "tester_count": 1,
   "bug_tracker": "github_issues",
-  "sessions_completed": 4
+  "sessions_completed": 4,
+  "features_since_last_health_check": 2
 }

--- a/.claude/build-progress.json
+++ b/.claude/build-progress.json
@@ -11,12 +11,12 @@
     "measurement-tool",
     "cross-section-slice-plane"
   ],
-  "features_since_last_test": 2,
+  "features_since_last_test": 0,
   "test_interval": 2,
   "last_test_session": "2026-04-08",
-  "testing_required": true,
+  "testing_required": false,
   "tester_count": 1,
   "bug_tracker": "github_issues",
-  "sessions_completed": 4,
+  "sessions_completed": 5,
   "features_since_last_health_check": 2
 }

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ build/
 # Solo Orchestrator logs
 .solo-orchestrator/
 .superpowers/
+.worktrees/

--- a/PROJECT_BIBLE.md
+++ b/PROJECT_BIBLE.md
@@ -253,6 +253,7 @@ nuitka --standalone
        --include-module=vtkmodules.vtkIOPLY
        --include-module=vtkmodules.vtkIOLegacy
        --include-module=vtkmodules.qt.QVTKRenderWindowInteractor
+       --include-module=vtkmodules.vtkInteractionWidgets
        --nofollow-import-to=vtkmodules.test
        --nofollow-import-to=vtkmodules.web
        --nofollow-import-to=vtkmodules.wx

--- a/src/meshscope/ui/main_window.py
+++ b/src/meshscope/ui/main_window.py
@@ -13,6 +13,7 @@ from PySide6.QtGui import (
     QDropEvent,
     QKeySequence,
     QMouseEvent,
+    QShortcut,
 )
 from PySide6.QtWidgets import (
     QComboBox,
@@ -111,6 +112,11 @@ class MainWindow(QMainWindow):
         status_bar.setAccessibleName("Status bar")
         self.setStatusBar(status_bar)
         self.statusBar().showMessage("Ready")
+
+        # Escape shortcut (window-level so it works regardless of focus)
+        escape_shortcut = QShortcut(QKeySequence(Qt.Key.Key_Escape), self)
+        escape_shortcut.setContext(Qt.ShortcutContext.WindowShortcut)
+        escape_shortcut.activated.connect(self._on_escape)
 
         # Connect slice overlay signals
         self._viewport.slice_overlay.preset_clicked.connect(self._on_slice_preset)
@@ -494,7 +500,7 @@ class MainWindow(QMainWindow):
         # Refresh slice plane if active
         if self.slice_action.isChecked():
             self._viewport.scene_manager.activate_slice_plane(
-                self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+                self._viewport.vtk_interactor
             )
         self._viewport.vtk_render()
 
@@ -529,7 +535,7 @@ class MainWindow(QMainWindow):
         # Refresh slice plane if active
         if self.slice_action.isChecked():
             self._viewport.scene_manager.activate_slice_plane(
-                self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+                self._viewport.vtk_interactor
             )
         self._viewport.vtk_render()
 
@@ -648,7 +654,7 @@ class MainWindow(QMainWindow):
         # Refresh slice plane if active
         if self.slice_action.isChecked():
             self._viewport.scene_manager.activate_slice_plane(
-                self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+                self._viewport.vtk_interactor
             )
         self._viewport.vtk_render()
 
@@ -751,7 +757,7 @@ class MainWindow(QMainWindow):
         # Refresh slice plane if active
         if self.slice_action.isChecked():
             self._viewport.scene_manager.activate_slice_plane(
-                self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+                self._viewport.vtk_interactor
             )
         self._viewport.vtk_render()
 
@@ -1160,13 +1166,14 @@ class MainWindow(QMainWindow):
             self.measure_action.setChecked(False)
 
         if had_measurements:
+            self._viewport.vtk_render()
             self.statusBar().showMessage(
                 "Measurements cleared \u2014 mesh geometry changed"
             )
 
-    def keyPressEvent(self, event: QEvent) -> None:
-        """Handle key press events."""
-        if event.key() == Qt.Key.Key_Escape and self.slice_action.isChecked():
+    def _on_escape(self) -> None:
+        """Handle Escape key — exit active modes."""
+        if self.slice_action.isChecked():
             self.slice_action.setChecked(False)
-            return
-        super().keyPressEvent(event)
+        elif self._measure_mode_active:
+            self.measure_action.setChecked(False)

--- a/src/meshscope/ui/main_window.py
+++ b/src/meshscope/ui/main_window.py
@@ -112,6 +112,10 @@ class MainWindow(QMainWindow):
         self.setStatusBar(status_bar)
         self.statusBar().showMessage("Ready")
 
+        # Connect slice overlay signals
+        self._viewport.slice_overlay.preset_clicked.connect(self._on_slice_preset)
+        self._viewport.slice_overlay.reset_clicked.connect(self._on_slice_reset)
+
         # Load file from CLI argument
         if file_path is not None:
             self._load_file(Path(file_path))
@@ -199,6 +203,13 @@ class MainWindow(QMainWindow):
         self.transform_action.setToolTip("Scale, rotate, or mirror mesh")
         self.transform_action.triggered.connect(self._on_transform)
 
+        self.slice_action = QAction("Slice", self)
+        self.slice_action.setShortcut(QKeySequence("C"))
+        self.slice_action.setCheckable(True)
+        self.slice_action.setEnabled(False)
+        self.slice_action.setToolTip("Toggle cross-section slice plane")
+        self.slice_action.toggled.connect(self._on_slice_toggled)
+
         self.measure_action = QAction("Measure", self)
         self.measure_action.setShortcut(QKeySequence("M"))
         self.measure_action.setCheckable(True)
@@ -243,6 +254,7 @@ class MainWindow(QMainWindow):
         view_menu.addAction(self.bed_action)
         view_menu.addAction(self.analyze_action)
         view_menu.addAction(self.repair_action)
+        view_menu.addAction(self.slice_action)
 
         help_menu = self.menuBar().addMenu("&Help")
         about_action = QAction("About", self)
@@ -289,6 +301,7 @@ class MainWindow(QMainWindow):
         self.toolbar.addAction(self.analyze_action)
         self.toolbar.addAction(self.repair_action)
         self.toolbar.addAction(self.transform_action)
+        self.toolbar.addAction(self.slice_action)
         self.toolbar.addAction(self.measure_action)
 
     # --- File loading ---
@@ -319,6 +332,9 @@ class MainWindow(QMainWindow):
             self._is_loading = False
 
         self._document = doc
+        # Exit slice mode on new file load
+        if self.slice_action.isChecked():
+            self.slice_action.setChecked(False)
         self._invalidate_measurements()
         self._info_panel.clear_analysis()
         self._viewport.scene_manager.hide_highlights()
@@ -373,6 +389,9 @@ class MainWindow(QMainWindow):
         self.bed_preset_combo.setEnabled(enabled)
         self.analyze_action.setEnabled(enabled)
         self.transform_action.setEnabled(enabled)
+        self.slice_action.setEnabled(enabled)
+        if not enabled and self.slice_action.isChecked():
+            self.slice_action.setChecked(False)
         self.measure_action.setEnabled(enabled)
         if not enabled:
             self.measure_action.setChecked(False)
@@ -472,6 +491,11 @@ class MainWindow(QMainWindow):
 
         polydata = mesh_data_to_polydata(self._document.mesh)
         self._viewport.scene_manager.display_mesh(polydata, auto_fit=False)
+        # Refresh slice plane if active
+        if self.slice_action.isChecked():
+            self._viewport.scene_manager.activate_slice_plane(
+                self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+            )
         self._viewport.vtk_render()
 
         self._info_panel.set_document(self._document)
@@ -502,6 +526,11 @@ class MainWindow(QMainWindow):
 
         polydata = mesh_data_to_polydata(self._document.mesh)
         self._viewport.scene_manager.display_mesh(polydata, auto_fit=False)
+        # Refresh slice plane if active
+        if self.slice_action.isChecked():
+            self._viewport.scene_manager.activate_slice_plane(
+                self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+            )
         self._viewport.vtk_render()
 
         self._info_panel.set_document(self._document)
@@ -616,6 +645,11 @@ class MainWindow(QMainWindow):
         # Update viewport
         polydata = mesh_data_to_polydata(self._document.mesh)
         self._viewport.scene_manager.display_mesh(polydata, auto_fit=False)
+        # Refresh slice plane if active
+        if self.slice_action.isChecked():
+            self._viewport.scene_manager.activate_slice_plane(
+                self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+            )
         self._viewport.vtk_render()
 
         # Update info panel with new mesh metadata
@@ -714,6 +748,11 @@ class MainWindow(QMainWindow):
         # Update viewport
         polydata = mesh_data_to_polydata(self._document.mesh)
         self._viewport.scene_manager.display_mesh(polydata, auto_fit=False)
+        # Refresh slice plane if active
+        if self.slice_action.isChecked():
+            self._viewport.scene_manager.activate_slice_plane(
+                self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+            )
         self._viewport.vtk_render()
 
         # Update info panel
@@ -915,6 +954,45 @@ class MainWindow(QMainWindow):
         save_config(self._config)
         return True
 
+    # --- Slice plane ---
+
+    def _on_slice_toggled(self, checked: bool) -> None:
+        """Toggle cross-section slice plane on/off."""
+        if checked and self._document is not None:
+            interactor = self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
+            self._viewport.scene_manager.activate_slice_plane(interactor)
+            self._viewport.slice_overlay.set_active_preset("z")
+            self._viewport.slice_overlay.show_overlay()
+            self.statusBar().showMessage(
+                "Slice plane active \u2014 drag to move, rotate handles to tilt"
+            )
+        else:
+            self._viewport.scene_manager.deactivate_slice_plane()
+            self._viewport.slice_overlay.hide_overlay()
+            self._viewport.vtk_render()
+            if self._document is not None:
+                self.statusBar().showMessage("Slice plane removed")
+            # Uncheck action if called programmatically
+            if self.slice_action.isChecked():
+                self.slice_action.blockSignals(True)
+                self.slice_action.setChecked(False)
+                self.slice_action.blockSignals(False)
+
+        self._viewport.vtk_render()
+
+    def _on_slice_preset(self, axis: str) -> None:
+        """Handle slice preset button click."""
+        self._viewport.scene_manager.set_slice_preset(axis)
+        self._viewport.slice_overlay.set_active_preset(axis)
+        self._viewport.vtk_render()
+        self.statusBar().showMessage(f"Slice plane: {axis.upper()} axis")
+
+    def _on_slice_reset(self) -> None:
+        """Handle slice reset button click."""
+        self._viewport.scene_manager.reset_slice_plane()
+        self._viewport.vtk_render()
+        self.statusBar().showMessage("Slice plane reset to model center")
+
     # --- Drag and drop ---
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
@@ -1081,3 +1159,10 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage(
                 "Measurements cleared \u2014 mesh geometry changed"
             )
+
+    def keyPressEvent(self, event: QEvent) -> None:
+        """Handle key press events."""
+        if event.key() == Qt.Key.Key_Escape and self.slice_action.isChecked():
+            self.slice_action.setChecked(False)
+            return
+        super().keyPressEvent(event)

--- a/src/meshscope/ui/main_window.py
+++ b/src/meshscope/ui/main_window.py
@@ -959,8 +959,9 @@ class MainWindow(QMainWindow):
     def _on_slice_toggled(self, checked: bool) -> None:
         """Toggle cross-section slice plane on/off."""
         if checked and self._document is not None:
-            interactor = self._viewport.vtk_interactor.GetRenderWindow().GetInteractor()
-            self._viewport.scene_manager.activate_slice_plane(interactor)
+            self._viewport.scene_manager.activate_slice_plane(
+                self._viewport.vtk_interactor
+            )
             self._viewport.slice_overlay.set_active_preset("z")
             self._viewport.slice_overlay.show_overlay()
             self.statusBar().showMessage(
@@ -1040,7 +1041,11 @@ class MainWindow(QMainWindow):
                 )
 
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:
-        """Intercept mouse events on the VTK interactor for measurement clicks."""
+        """Intercept left-click on the VTK interactor for measurement point placement.
+
+        In measure mode, left-click is consumed to prevent VTK orbit rotation.
+        Right-click drag (zoom) and middle-click drag (pan) still work normally.
+        """
         if not self._measure_mode_active:
             return False
 
@@ -1050,6 +1055,7 @@ class MainWindow(QMainWindow):
         if event.type() == QEvent.Type.MouseButtonPress:
             if event.button() == Qt.MouseButton.LeftButton:
                 self._mouse_press_pos = event.position().toPoint()
+                return True  # consume press to prevent VTK orbit
             return False
 
         if event.type() == QEvent.Type.MouseButtonRelease:
@@ -1058,15 +1064,13 @@ class MainWindow(QMainWindow):
                 and self._mouse_press_pos is not None
             ):
                 release_pos = event.position().toPoint()
-                dx = abs(release_pos.x() - self._mouse_press_pos.x())
-                dy = abs(release_pos.y() - self._mouse_press_pos.y())
                 self._mouse_press_pos = None
-
-                if dx < 5 and dy < 5:
-                    self._handle_measure_click(release_pos.x(), release_pos.y())
-                    return True
-
+                self._handle_measure_click(release_pos.x(), release_pos.y())
+                return True
             return False
+
+        if event.type() == QEvent.Type.MouseMove:
+            return self._mouse_press_pos is not None
 
         return False
 

--- a/src/meshscope/ui/slice_overlay.py
+++ b/src/meshscope/ui/slice_overlay.py
@@ -32,10 +32,11 @@ QPushButton.preset-btn {
     color: #ccc;
     border: 1px solid #555;
     border-radius: 3px;
-    padding: 4px 10px;
-    font-size: 12px;
+    padding: 6px 12px;
+    font-size: 13px;
     font-weight: bold;
-    min-width: 24px;
+    min-width: 28px;
+    min-height: 24px;
 }
 QPushButton.preset-btn:hover {
     background-color: #444;
@@ -51,8 +52,9 @@ QPushButton#btn_reset {
     color: #ccc;
     border: 1px solid #555;
     border-radius: 3px;
-    padding: 4px 8px;
-    font-size: 11px;
+    padding: 6px 8px;
+    font-size: 12px;
+    min-height: 24px;
 }
 QPushButton#btn_reset:hover {
     background-color: #444;
@@ -78,11 +80,12 @@ class SliceOverlayWidget(QWidget):
         self.setObjectName("SliceOverlayWidget")
         self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         self.setStyleSheet(_OVERLAY_STYLE)
-        self.setFixedWidth(110)
+        self.setFixedWidth(130)
+        self.setMinimumHeight(100)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(8, 6, 8, 6)
-        layout.setSpacing(6)
+        layout.setContentsMargins(10, 8, 10, 8)
+        layout.setSpacing(8)
 
         # Title
         title = QLabel("Slice Plane")

--- a/src/meshscope/ui/slice_overlay.py
+++ b/src/meshscope/ui/slice_overlay.py
@@ -1,0 +1,141 @@
+"""Floating overlay widget for slice plane controls.
+
+Provides X/Y/Z preset buttons and Reset, positioned over the 3D viewport.
+Only visible while slice mode is active.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+# Stylesheet for the overlay panel
+_OVERLAY_STYLE = """
+SliceOverlayWidget {
+    background-color: rgba(38, 38, 38, 238);
+    border: 1px solid #444;
+    border-radius: 6px;
+}
+QLabel#title {
+    color: #ccc;
+    font-size: 11px;
+    font-weight: bold;
+}
+QPushButton.preset-btn {
+    background-color: #333;
+    color: #ccc;
+    border: 1px solid #555;
+    border-radius: 3px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: bold;
+    min-width: 24px;
+}
+QPushButton.preset-btn:hover {
+    background-color: #444;
+    border-color: #89b4fa;
+}
+QPushButton.preset-btn[active="true"] {
+    background-color: #89b4fa;
+    color: #1a1a1a;
+    border-color: #89b4fa;
+}
+QPushButton#btn_reset {
+    background-color: #333;
+    color: #ccc;
+    border: 1px solid #555;
+    border-radius: 3px;
+    padding: 4px 8px;
+    font-size: 11px;
+}
+QPushButton#btn_reset:hover {
+    background-color: #444;
+    border-color: #89b4fa;
+}
+"""
+
+
+class SliceOverlayWidget(QWidget):
+    """Floating overlay for slice plane controls. Parented to viewport widget.
+
+    Signals:
+        preset_clicked(str): Emitted when X, Y, or Z button is clicked.
+            Payload is 'x', 'y', or 'z'.
+        reset_clicked(): Emitted when Reset button is clicked.
+    """
+
+    preset_clicked = Signal(str)
+    reset_clicked = Signal()
+
+    def __init__(self, parent: QWidget | None) -> None:
+        super().__init__(parent)
+        self.setObjectName("SliceOverlayWidget")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setStyleSheet(_OVERLAY_STYLE)
+        self.setFixedWidth(110)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setSpacing(6)
+
+        # Title
+        title = QLabel("Slice Plane")
+        title.setObjectName("title")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(title)
+
+        # Preset buttons row
+        row = QHBoxLayout()
+        row.setSpacing(4)
+
+        self._preset_buttons: dict[str, QPushButton] = {}
+        for axis in ("x", "y", "z"):
+            btn = QPushButton(axis.upper())
+            btn.setObjectName(f"btn_{axis}")
+            btn.setProperty("class", "preset-btn")
+            btn.setAccessibleName(f"Slice preset {axis.upper()} axis")
+            btn.clicked.connect(
+                lambda checked=False, a=axis: self.preset_clicked.emit(a)
+            )
+            row.addWidget(btn)
+            self._preset_buttons[axis] = btn
+
+        layout.addLayout(row)
+
+        # Reset button
+        reset_btn = QPushButton("Reset")
+        reset_btn.setObjectName("btn_reset")
+        reset_btn.setAccessibleName("Reset slice plane to model center")
+        reset_btn.clicked.connect(self.reset_clicked.emit)
+        layout.addWidget(reset_btn)
+
+        # Start hidden
+        self.hide()
+
+    def set_active_preset(self, axis: str | None) -> None:
+        """Highlight the active preset button, clearing others.
+
+        Args:
+            axis: 'x', 'y', 'z' to highlight, or None to clear all.
+        """
+        for key, btn in self._preset_buttons.items():
+            is_active = axis is not None and key == axis.lower()
+            btn.setProperty("active", is_active)
+            # Force stylesheet recalculation
+            btn.style().unpolish(btn)
+            btn.style().polish(btn)
+
+    def show_overlay(self) -> None:
+        """Show the overlay panel."""
+        self.show()
+        self.raise_()
+
+    def hide_overlay(self) -> None:
+        """Hide the overlay panel."""
+        self.hide()

--- a/src/meshscope/ui/viewport_widget.py
+++ b/src/meshscope/ui/viewport_widget.py
@@ -14,6 +14,7 @@ from vtkmodules.vtkInteractionStyle import (
 from vtkmodules.vtkRenderingCore import vtkRenderer
 from vtkmodules.vtkRenderingOpenGL2 import vtkOpenGLRenderer  # noqa: F401
 
+from meshscope.ui.slice_overlay import SliceOverlayWidget
 from meshscope.vtk_adapter.scene_manager import SceneManager
 
 logger = logging.getLogger("meshscope.ui.viewport_widget")
@@ -58,6 +59,9 @@ class ViewportWidget(QWidget):
         self._empty_label.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
         self._empty_label.setAccessibleName("Viewport empty state prompt")
 
+        # Slice plane overlay (floating panel, top-right)
+        self._slice_overlay = SliceOverlayWidget(self)
+
     @property
     def renderer(self) -> vtkRenderer:
         return self._renderer
@@ -77,6 +81,10 @@ class ViewportWidget(QWidget):
     @property
     def vtk_interactor(self) -> QVTKRenderWindowInteractor:
         return self._vtk_widget
+
+    @property
+    def slice_overlay(self) -> SliceOverlayWidget:
+        return self._slice_overlay
 
     def set_state(self, state: str) -> None:
         """Set the viewport state: 'empty', 'loading', 'success', 'error'."""
@@ -118,6 +126,10 @@ class ViewportWidget(QWidget):
         self._vtk_widget.GetRenderWindow().Render()  # type: ignore[no-untyped-call]
 
     def resizeEvent(self, event: QResizeEvent) -> None:
-        """Reposition the overlay label on resize."""
+        """Reposition the overlay label and slice overlay on resize."""
         super().resizeEvent(event)
         self._empty_label.setGeometry(self.rect())
+        # Position slice overlay at top-right corner with 10px margin
+        if hasattr(self, "_slice_overlay"):
+            overlay_x = self.width() - self._slice_overlay.width() - 10
+            self._slice_overlay.move(overlay_x, 10)

--- a/src/meshscope/vtk_adapter/scene_manager.py
+++ b/src/meshscope/vtk_adapter/scene_manager.py
@@ -23,6 +23,7 @@ from meshscope.core.mesh_data import BoundingBox
 from meshscope.vtk_adapter.highlight_manager import HighlightManager
 from meshscope.vtk_adapter.measurement_manager import MeasurementManager
 from meshscope.vtk_adapter.print_bed import PrintBedManager, get_overflow_text
+from meshscope.vtk_adapter.slice_plane_manager import SlicePlaneManager
 
 if TYPE_CHECKING:
     from meshscope.core.mesh_analysis import MeshAnalysis
@@ -59,6 +60,7 @@ class SceneManager:
         self._highlight_actors: list[vtkActor] = []
         self._highlight_manager = HighlightManager()
         self._highlights_visible = False
+        self._slice_manager: SlicePlaneManager | None = None
         self._measurement_actors: list[vtkActor] = []
         self._measurement_manager = MeasurementManager()
         self._measurements_visible = False
@@ -108,6 +110,7 @@ class SceneManager:
 
     def clear(self) -> None:
         """Remove all mesh actors from the scene."""
+        self.deactivate_slice_plane()
         if self._mesh_actor is not None:
             self._renderer.RemoveActor(self._mesh_actor)
             self._mesh_actor = None
@@ -147,6 +150,90 @@ class SceneManager:
     @property
     def highlights_visible(self) -> bool:
         return self._highlights_visible
+
+    # --- Slice Plane ---
+
+    def activate_slice_plane(self, interactor: Any) -> None:
+        """Activate the slice plane. Requires a mesh to be displayed.
+
+        Args:
+            interactor: The vtkRenderWindowInteractor from the viewport widget.
+        """
+        if self._mesh_actor is None:
+            logger.debug("Cannot activate slice plane — no mesh displayed")
+            return
+
+        polydata = self._mesh_actor.GetMapper().GetInput()
+        if polydata is None:
+            return
+
+        bounds = polydata.GetBounds()
+
+        if self._slice_manager is None:
+            self._slice_manager = SlicePlaneManager(self._renderer, interactor)
+
+        # Hide the original mesh actor — the clipped actor replaces it
+        self._mesh_actor.SetVisibility(False)
+        if self._wireframe_actor is not None:
+            self._wireframe_actor.SetVisibility(False)
+
+        self._slice_manager.activate(polydata, bounds)
+
+    def deactivate_slice_plane(self) -> None:
+        """Deactivate the slice plane and restore the full mesh."""
+        if self._slice_manager is not None:
+            self._slice_manager.deactivate()
+
+        # Restore original mesh actor visibility
+        if self._mesh_actor is not None:
+            self._mesh_actor.SetVisibility(True)
+            if self._wireframe_actor is not None and self._wireframe_overlay_enabled:
+                self._wireframe_actor.SetVisibility(True)
+
+    @property
+    def slice_active(self) -> bool:
+        """Whether the slice plane is currently active."""
+        if self._slice_manager is None:
+            return False
+        return self._slice_manager.is_active
+
+    @property
+    def slice_current_preset(self) -> str | None:
+        """The current slice preset axis, or None if manual."""
+        if self._slice_manager is None:
+            return None
+        return self._slice_manager.current_preset
+
+    def set_slice_preset(self, axis: str) -> None:
+        """Snap the slice plane to the given axis preset."""
+        if self._slice_manager is None or self._mesh_actor is None:
+            return
+        polydata = self._mesh_actor.GetMapper().GetInput()
+        if polydata is None:
+            return
+        bounds = polydata.GetBounds()
+        self._slice_manager.set_preset(axis, bounds)
+
+    def reset_slice_plane(self) -> None:
+        """Reset the slice plane to the center of the model."""
+        if self._slice_manager is None or self._mesh_actor is None:
+            return
+        polydata = self._mesh_actor.GetMapper().GetInput()
+        if polydata is None:
+            return
+        bounds = polydata.GetBounds()
+        self._slice_manager.reset_to_center(bounds)
+
+    def update_slice_mesh(self, polydata: vtkPolyData) -> None:
+        """Update the slice plane with new mesh data (after transform/undo).
+
+        Args:
+            polydata: The updated mesh polydata.
+        """
+        if self._slice_manager is None or not self._slice_manager.is_active:
+            return
+        bounds = polydata.GetBounds()
+        self._slice_manager.update_mesh(polydata, bounds)
 
     # --- Measurements ---
 

--- a/src/meshscope/vtk_adapter/slice_plane_manager.py
+++ b/src/meshscope/vtk_adapter/slice_plane_manager.py
@@ -1,0 +1,433 @@
+"""Cross-section slice plane manager for VTK viewport.
+
+Manages the VTK clipping pipeline:
+  vtkImplicitPlaneWidget2 -> vtkPlane -> vtkClipClosedSurface -> actors
+
+Provides activate/deactivate lifecycle, preset positioning (X/Y/Z),
+reset to center, and mesh update for transform/repair/undo.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from vtkmodules.vtkCommonDataModel import vtkPlane, vtkPolyData
+from vtkmodules.vtkRenderingCore import (
+    vtkActor,
+    vtkPolyDataMapper,
+    vtkRenderer,
+)
+
+if TYPE_CHECKING:
+    from vtkmodules.vtkRenderingCore import vtkRenderWindowInteractor
+
+logger = logging.getLogger("meshscope.vtk_adapter.slice_plane_manager")
+
+# Interior fill color: terracotta (#c06040)
+CAP_COLOR = (0.753, 0.376, 0.251)
+
+# Plane widget color: theme blue (#89b4fa)
+PLANE_WIDGET_COLOR = (0.537, 0.706, 0.980)
+
+
+def _try_clip_closed_surface(
+    polydata: vtkPolyData, plane: vtkPlane
+) -> tuple[vtkPolyData | None, bool]:
+    """Attempt to clip with vtkClipClosedSurface (generates cap polygons).
+
+    Returns (clipped_polydata, has_cap). If unavailable or fails,
+    returns (None, False).
+    """
+    try:
+        from vtkmodules.vtkCommonDataModel import vtkPlaneCollection
+        from vtkmodules.vtkFiltersGeneral import vtkClipClosedSurface
+    except ImportError:
+        logger.warning("vtkClipClosedSurface not available, using fallback")
+        return None, False
+
+    try:
+        plane_collection = vtkPlaneCollection()
+        plane_collection.AddItem(plane)
+
+        clipper = vtkClipClosedSurface()
+        clipper.SetInputData(polydata)
+        clipper.SetClippingPlanes(plane_collection)
+        clipper.SetGenerateFaces(True)
+        clipper.SetGenerateOutline(False)
+        clipper.SetScalarModeToColors()
+
+        # Set cap color via the clipper's base/cap color
+        clipper.SetBaseColor(*CAP_COLOR)
+        clipper.SetClipColor(*CAP_COLOR)
+
+        clipper.Update()
+        result = clipper.GetOutput()
+
+        if result is None or result.GetNumberOfCells() == 0:
+            return None, False
+
+        return result, True
+    except Exception:
+        logger.warning("vtkClipClosedSurface failed, using fallback", exc_info=True)
+        return None, False
+
+
+def _clip_polydata_fallback(
+    polydata: vtkPolyData, plane: vtkPlane
+) -> vtkPolyData | None:
+    """Fallback: clip with vtkClipPolyData (no cap generation)."""
+    try:
+        from vtkmodules.vtkFiltersCore import vtkClipPolyData
+    except ImportError:
+        logger.error("vtkClipPolyData not available — cannot clip")
+        return None
+
+    try:
+        clipper = vtkClipPolyData()
+        clipper.SetInputData(polydata)
+        clipper.SetClipFunction(plane)
+        clipper.SetInsideOut(False)
+        clipper.Update()
+        result = clipper.GetOutput()
+        if result is None or result.GetNumberOfCells() == 0:
+            return None
+        return result
+    except Exception:
+        logger.warning("vtkClipPolyData failed", exc_info=True)
+        return None
+
+
+class SlicePlaneManager:
+    """Manages the VTK clipping pipeline and interactive plane widget.
+
+    Lifecycle:
+      activate(polydata, bounds) -> show plane widget + clipped mesh
+      deactivate() -> remove plane widget + restore full mesh
+      set_preset(axis, bounds) -> snap plane to X/Y/Z axis
+      reset_to_center(bounds) -> move plane to center, keep orientation
+      update_mesh(polydata, bounds) -> recalculate clip after transform/undo
+    """
+
+    def __init__(
+        self,
+        renderer: vtkRenderer,
+        interactor: vtkRenderWindowInteractor,
+    ) -> None:
+        self._renderer = renderer
+        self._interactor = interactor
+        self._active = False
+
+        # VTK pipeline objects (created on activate)
+        self._plane: vtkPlane | None = None
+        self._widget = None  # vtkImplicitPlaneWidget2
+        self._polydata: vtkPolyData | None = None
+        self._bounds: tuple[float, ...] = ()
+
+        # Actors managed by this manager
+        self._clipped_actor: vtkActor | None = None
+        self._cap_actor: vtkActor | None = None
+        self._has_cap = False
+
+        # Current preset axis (None if manually rotated)
+        self._current_preset: str | None = "z"
+
+        # Callback tag for cleanup
+        self._callback_tag: int | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """Whether the slice plane is currently active."""
+        return self._active
+
+    @property
+    def current_preset(self) -> str | None:
+        """The current preset axis ('x', 'y', 'z') or None if manual."""
+        return self._current_preset
+
+    def activate(self, polydata: vtkPolyData, bounds: tuple[float, ...]) -> None:
+        """Show the plane widget and start clipping.
+
+        Initializes plane at center of bounds, oriented along Z axis.
+        If already active, deactivates first to avoid duplicate actors.
+        """
+        if self._active:
+            self.deactivate()
+
+        self._polydata = polydata
+        self._bounds = bounds
+        self._current_preset = "z"
+
+        # Compute center from bounds (xmin, xmax, ymin, ymax, zmin, zmax)
+        center = (
+            (bounds[0] + bounds[1]) / 2,
+            (bounds[2] + bounds[3]) / 2,
+            (bounds[4] + bounds[5]) / 2,
+        )
+
+        # Create the implicit plane
+        self._plane = vtkPlane()
+        self._plane.SetOrigin(*center)
+        self._plane.SetNormal(0, 0, 1)  # Z axis default
+
+        # Create the interactive widget
+        self._setup_widget(bounds, center)
+
+        # Perform initial clip
+        self._update_clip()
+
+        self._active = True
+        logger.debug(
+            "Slice plane activated at center (%.1f, %.1f, %.1f)",
+            *center,
+        )
+
+    def deactivate(self) -> None:
+        """Remove plane widget and all clipping actors."""
+        if not self._active and self._widget is None:
+            return
+
+        # Remove widget
+        if self._widget is not None:
+            if self._callback_tag is not None:
+                self._widget.RemoveObserver(self._callback_tag)
+                self._callback_tag = None
+            self._widget.Off()
+            self._widget = None
+
+        # Remove actors
+        self._remove_clip_actors()
+
+        # Reset state
+        self._plane = None
+        self._polydata = None
+        self._bounds = ()
+        self._active = False
+        self._current_preset = "z"
+
+        logger.debug("Slice plane deactivated")
+
+    def set_preset(self, axis: str, bounds: tuple[float, ...]) -> None:
+        """Snap plane to X, Y, or Z axis through center of bounds.
+
+        Args:
+            axis: 'x', 'y', or 'z'
+            bounds: (xmin, xmax, ymin, ymax, zmin, zmax)
+        """
+        if not self._active or self._plane is None:
+            return
+
+        center = (
+            (bounds[0] + bounds[1]) / 2,
+            (bounds[2] + bounds[3]) / 2,
+            (bounds[4] + bounds[5]) / 2,
+        )
+
+        normals = {"x": (1, 0, 0), "y": (0, 1, 0), "z": (0, 0, 1)}
+        normal = normals.get(axis.lower())
+        if normal is None:
+            logger.warning("Invalid preset axis: %s", axis)
+            return
+
+        self._plane.SetOrigin(*center)
+        self._plane.SetNormal(*normal)
+        self._bounds = bounds
+        self._current_preset = axis.lower()
+
+        # Update widget representation to match
+        self._sync_widget_to_plane()
+
+        # Recalculate clip
+        self._update_clip()
+
+        logger.debug("Slice plane preset: %s axis", axis.upper())
+
+    def reset_to_center(self, bounds: tuple[float, ...]) -> None:
+        """Move plane back to center of bounds, keeping current orientation.
+
+        Args:
+            bounds: (xmin, xmax, ymin, ymax, zmin, zmax)
+        """
+        if not self._active or self._plane is None:
+            return
+
+        center = (
+            (bounds[0] + bounds[1]) / 2,
+            (bounds[2] + bounds[3]) / 2,
+            (bounds[4] + bounds[5]) / 2,
+        )
+
+        self._plane.SetOrigin(*center)
+        self._bounds = bounds
+
+        # Update widget representation to match
+        self._sync_widget_to_plane()
+
+        # Recalculate clip
+        self._update_clip()
+
+        logger.debug("Slice plane reset to center")
+
+    def update_mesh(self, polydata: vtkPolyData, bounds: tuple[float, ...]) -> None:
+        """Update the clipped mesh after transform/repair/undo.
+
+        Keeps current plane position and orientation, recalculates clip
+        on the new mesh geometry.
+
+        Args:
+            polydata: Updated mesh polydata
+            bounds: Updated bounds (xmin, xmax, ymin, ymax, zmin, zmax)
+        """
+        if not self._active or self._plane is None:
+            return
+
+        self._polydata = polydata
+        self._bounds = bounds
+
+        # Update widget bounds so handles stay proportional
+        if self._widget is not None:
+            rep = self._widget.GetRepresentation()
+            rep.PlaceWidget(bounds)
+            rep.SetOrigin(self._plane.GetOrigin())
+            rep.SetNormal(self._plane.GetNormal())
+
+        # Recalculate clip
+        self._update_clip()
+
+        logger.debug("Slice plane mesh updated")
+
+    def _setup_widget(
+        self,
+        bounds: tuple[float, ...],
+        center: tuple[float, float, float],
+    ) -> None:
+        """Create and configure the vtkImplicitPlaneWidget2.
+
+        The widget is optional — clipping works without it. If the
+        interactor is unavailable or incompatible (e.g. in tests),
+        the widget setup is skipped gracefully.
+        """
+        try:
+            from vtkmodules.vtkInteractionWidgets import (
+                vtkImplicitPlaneRepresentation,
+                vtkImplicitPlaneWidget2,
+            )
+        except ImportError:
+            logger.warning(
+                "vtkInteractionWidgets not available — plane widget disabled"
+            )
+            return
+
+        try:
+            # Representation
+            rep = vtkImplicitPlaneRepresentation()
+            rep.SetPlaceFactor(1.0)
+            rep.PlaceWidget(bounds)
+            rep.SetOrigin(*center)
+            rep.SetNormal(0, 0, 1)  # Z axis default
+            rep.SetEdgeColor(*PLANE_WIDGET_COLOR)
+            rep.SetOutlineTranslation(False)
+            rep.SetScaleEnabled(False)
+
+            # Widget
+            widget = vtkImplicitPlaneWidget2()
+            widget.SetInteractor(self._interactor)
+            widget.SetRepresentation(rep)
+
+            # Callback for real-time clip update during drag
+            self._callback_tag = widget.AddObserver(
+                "InteractionEvent", self._on_interaction
+            )
+
+            widget.On()
+            self._widget = widget
+        except (TypeError, RuntimeError):
+            logger.warning(
+                "Could not initialize plane widget — interactor unavailable",
+                exc_info=True,
+            )
+
+    def _on_interaction(self, caller: object, event: str) -> None:
+        """Callback fired continuously during widget drag/rotate.
+
+        Reads the new plane position/normal from the widget representation
+        and recalculates the clip in real time.
+        """
+        if self._widget is None or self._plane is None:
+            return
+
+        rep = self._widget.GetRepresentation()
+        origin = rep.GetOrigin()
+        normal = rep.GetNormal()
+
+        self._plane.SetOrigin(origin)
+        self._plane.SetNormal(normal)
+
+        # User has manually moved/rotated — clear preset
+        self._current_preset = None
+
+        self._update_clip()
+
+    def _sync_widget_to_plane(self) -> None:
+        """Update the widget representation to match the current plane state."""
+        if self._widget is None or self._plane is None:
+            return
+
+        rep = self._widget.GetRepresentation()
+        rep.SetOrigin(self._plane.GetOrigin())
+        rep.SetNormal(self._plane.GetNormal())
+
+    def _update_clip(self) -> None:
+        """Recalculate the clipping and update actors.
+
+        Called on activate, preset change, reset, interaction, and mesh update.
+        """
+        if self._plane is None or self._polydata is None:
+            return
+
+        # Remove old actors
+        self._remove_clip_actors()
+
+        # Try vtkClipClosedSurface first (with cap)
+        clipped, has_cap = _try_clip_closed_surface(self._polydata, self._plane)
+
+        if clipped is not None:
+            self._has_cap = has_cap
+            # ClipClosedSurface produces a single polydata with cap colors embedded
+            mapper = vtkPolyDataMapper()
+            mapper.SetInputData(clipped)
+            mapper.SetScalarModeToUseCellFieldData()
+            mapper.SelectColorArray("Colors")
+            mapper.SetScalarVisibility(True)
+
+            self._clipped_actor = vtkActor()
+            self._clipped_actor.SetMapper(mapper)
+            self._renderer.AddActor(self._clipped_actor)
+        else:
+            # Fallback: vtkClipPolyData (no cap)
+            self._has_cap = False
+            fallback = _clip_polydata_fallback(self._polydata, self._plane)
+            if fallback is not None and fallback.GetNumberOfCells() > 0:
+                mapper = vtkPolyDataMapper()
+                mapper.SetInputData(fallback)
+
+                self._clipped_actor = vtkActor()
+                self._clipped_actor.SetMapper(mapper)
+                self._clipped_actor.GetProperty().SetColor(0.75, 0.75, 0.75)
+                self._renderer.AddActor(self._clipped_actor)
+            else:
+                # Plane is fully outside bounds — show nothing (full mesh
+                # visible because SceneManager keeps original mesh actor)
+                logger.debug("Clip produced empty result — plane outside bounds")
+
+    def _remove_clip_actors(self) -> None:
+        """Remove all clipping-related actors from the renderer."""
+        if self._clipped_actor is not None:
+            self._renderer.RemoveActor(self._clipped_actor)
+            self._clipped_actor = None
+
+        if self._cap_actor is not None:
+            self._renderer.RemoveActor(self._cap_actor)
+            self._cap_actor = None
+
+        self._has_cap = False

--- a/src/meshscope/vtk_adapter/slice_plane_manager.py
+++ b/src/meshscope/vtk_adapter/slice_plane_manager.py
@@ -10,7 +10,7 @@ reset to center, and mesh update for transform/repair/undo.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vtkmodules.vtkCommonDataModel import vtkPlane, vtkPolyData
 from vtkmodules.vtkRenderingCore import (
@@ -92,7 +92,7 @@ def _clip_polydata_fallback(
         result = clipper.GetOutput()
         if result is None or result.GetNumberOfCells() == 0:
             return None
-        return result
+        return result  # type: ignore[no-any-return]
     except Exception:
         logger.warning("vtkClipPolyData failed", exc_info=True)
         return None
@@ -120,7 +120,7 @@ class SlicePlaneManager:
 
         # VTK pipeline objects (created on activate)
         self._plane: vtkPlane | None = None
-        self._widget = None  # vtkImplicitPlaneWidget2
+        self._widget: Any = None  # vtkImplicitPlaneWidget2
         self._polydata: vtkPolyData | None = None
         self._bounds: tuple[float, ...] = ()
 
@@ -322,7 +322,7 @@ class SlicePlaneManager:
             # Representation
             rep = vtkImplicitPlaneRepresentation()
             rep.SetPlaceFactor(1.25)
-            rep.PlaceWidget(bounds)
+            rep.PlaceWidget(list(bounds))
             rep.SetOrigin(*center)
             rep.SetNormal(0, 0, 1)  # Z axis default
             rep.SetEdgeColor(*PLANE_WIDGET_COLOR)
@@ -338,9 +338,8 @@ class SlicePlaneManager:
             widget.SetRepresentation(rep)
 
             # Callback for real-time clip update during drag
-            self._callback_tag = widget.AddObserver(
-                "InteractionEvent", self._on_interaction
-            )
+            event_name: Any = "InteractionEvent"
+            self._callback_tag = widget.AddObserver(event_name, self._on_interaction)
 
             widget.On()
             self._widget = widget

--- a/src/meshscope/vtk_adapter/slice_plane_manager.py
+++ b/src/meshscope/vtk_adapter/slice_plane_manager.py
@@ -87,7 +87,7 @@ def _clip_polydata_fallback(
         clipper = vtkClipPolyData()
         clipper.SetInputData(polydata)
         clipper.SetClipFunction(plane)
-        clipper.SetInsideOut(False)
+        clipper.InsideOutOn()
         clipper.Update()
         result = clipper.GetOutput()
         if result is None or result.GetNumberOfCells() == 0:
@@ -321,13 +321,16 @@ class SlicePlaneManager:
         try:
             # Representation
             rep = vtkImplicitPlaneRepresentation()
-            rep.SetPlaceFactor(1.0)
+            rep.SetPlaceFactor(1.25)
             rep.PlaceWidget(bounds)
             rep.SetOrigin(*center)
             rep.SetNormal(0, 0, 1)  # Z axis default
             rep.SetEdgeColor(*PLANE_WIDGET_COLOR)
             rep.SetOutlineTranslation(False)
             rep.SetScaleEnabled(False)
+            # Larger handle for easier grabbing
+            rep.GetSelectedPlaneProperty().SetOpacity(0.3)
+            rep.SetHandleSize(15.0)
 
             # Widget
             widget = vtkImplicitPlaneWidget2()

--- a/tests/uat/sessions/session-5-f9-f10/test-session-5-v1.html
+++ b/tests/uat/sessions/session-5-f9-f10/test-session-5-v1.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>UAT Session 5 - meshscope</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #0f0f17; color: #cdd6f4; line-height: 1.5; padding: 24px; max-width: 960px; margin: 0 auto; }
+  h1 { font-size: 1.6rem; margin-bottom: 4px; }
+  .meta { color: #a6adc8; font-size: 0.9rem; margin-bottom: 24px; }
+  .progress-bar { background: #1e1e2e; border-radius: 8px; height: 8px; margin-bottom: 24px; overflow: hidden; }
+  .progress-fill { background: #a6e3a1; height: 100%; width: 0%; transition: width 0.3s; }
+  .progress-text { text-align: center; color: #a6adc8; font-size: 0.85rem; margin-bottom: 24px; }
+  h2 { font-size: 1.2rem; color: #89b4fa; margin: 32px 0 16px; padding-bottom: 8px; border-bottom: 1px solid #313244; }
+  .fixture-ref { background: #11111b; border: 1px solid #313244; border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; font-size: 0.85rem; color: #a6adc8; }
+  .fixture-ref strong { color: #cdd6f4; }
+  .fixture-ref code { background: #313244; padding: 2px 6px; border-radius: 3px; color: #f9e2af; }
+  .scenario { background: #1e1e2e; border-radius: 8px; margin-bottom: 12px; overflow: hidden; border-left: 4px solid #45475a; transition: border-color 0.2s; }
+  .scenario.pass { border-left-color: #a6e3a1; }
+  .scenario.fail { border-left-color: #f38ba8; }
+  .scenario-header { padding: 12px 16px; display: flex; align-items: center; gap: 12px; }
+  .scenario-num { background: #313244; color: #a6adc8; font-size: 0.8rem; font-weight: 600; padding: 2px 8px; border-radius: 4px; min-width: 28px; text-align: center; }
+  .scenario-title { flex: 1; font-weight: 500; }
+  .btn-group { display: flex; gap: 4px; }
+  .btn { padding: 6px 14px; border: 1px solid #45475a; border-radius: 4px; background: transparent; color: #cdd6f4; cursor: pointer; font-size: 0.85rem; transition: all 0.15s; }
+  .btn:hover { background: #313244; }
+  .btn.pass-btn.active { background: #a6e3a1; color: #1e1e2e; border-color: #a6e3a1; font-weight: 600; }
+  .btn.fail-btn.active { background: #f38ba8; color: #1e1e2e; border-color: #f38ba8; font-weight: 600; }
+  .btn.skip-btn.active { background: #f9e2af; color: #1e1e2e; border-color: #f9e2af; font-weight: 600; }
+  .scenario-details { padding: 0 16px 8px 16px; display: none; }
+  .scenario-details.open { display: block; }
+  .steps { background: #11111b; padding: 10px 14px; border-radius: 4px; font-size: 0.85rem; color: #a6adc8; margin-bottom: 8px; }
+  .steps strong { color: #cdd6f4; }
+  .scenario-notes { padding: 4px 16px 12px 16px; }
+  .notes-input { width: 100%; background: #11111b; border: 1px solid #45475a; color: #cdd6f4; padding: 8px 12px; border-radius: 4px; font-size: 0.85rem; font-family: inherit; resize: vertical; min-height: 36px; }
+  .notes-input:focus { outline: none; border-color: #89b4fa; }
+  .toggle-details { background: none; border: none; color: #6c7086; cursor: pointer; font-size: 0.75rem; padding: 4px 8px; }
+  .toggle-details:hover { color: #89b4fa; }
+  .bugs-section { margin-top: 40px; }
+  .bug-entry { background: #1e1e2e; border-radius: 8px; padding: 16px; margin-bottom: 12px; border-left: 4px solid #f38ba8; }
+  .bug-row { display: flex; gap: 12px; margin-bottom: 8px; flex-wrap: wrap; }
+  .bug-field { flex: 1; min-width: 200px; }
+  .bug-field label { display: block; color: #a6adc8; font-size: 0.8rem; margin-bottom: 4px; }
+  .bug-field input, .bug-field select, .bug-field textarea { width: 100%; background: #11111b; border: 1px solid #45475a; color: #cdd6f4; padding: 8px 12px; border-radius: 4px; font-size: 0.85rem; font-family: inherit; }
+  .bug-field textarea { resize: vertical; min-height: 60px; }
+  .bug-field input:focus, .bug-field select:focus, .bug-field textarea:focus { outline: none; border-color: #89b4fa; }
+  .bug-field select { appearance: auto; }
+  .add-bug-btn { background: #313244; border: 1px dashed #45475a; color: #a6adc8; padding: 10px; border-radius: 8px; width: 100%; cursor: pointer; font-size: 0.85rem; margin-bottom: 12px; }
+  .add-bug-btn:hover { border-color: #f38ba8; color: #f38ba8; }
+  .remove-bug { background: none; border: none; color: #f38ba8; cursor: pointer; font-size: 0.8rem; float: right; }
+  .overall-notes { margin-top: 32px; }
+  .overall-notes textarea { width: 100%; background: #11111b; border: 1px solid #45475a; color: #cdd6f4; padding: 12px; border-radius: 8px; font-size: 0.9rem; font-family: inherit; resize: vertical; min-height: 100px; }
+  .overall-notes textarea:focus { outline: none; border-color: #89b4fa; }
+  .export-section { margin-top: 32px; text-align: center; padding: 24px; }
+  .export-btn { background: #89b4fa; color: #1e1e2e; border: none; padding: 12px 32px; border-radius: 8px; font-size: 1rem; font-weight: 600; cursor: pointer; }
+  .export-btn:hover { background: #74c7ec; }
+  .export-btn:active { transform: scale(0.98); }
+  .copy-msg { color: #a6e3a1; margin-top: 8px; font-size: 0.85rem; display: none; }
+</style>
+</head>
+<body>
+
+<h1>UAT Session 5</h1>
+<div class="meta">Date: 2026-04-08 | Features: Measurement Tool + Cross-Section Slice Plane | Tester: <input id="tester-name" type="text" placeholder="Your name" style="background:#1e1e2e;border:1px solid #45475a;color:#cdd6f4;padding:4px 8px;border-radius:4px;font-size:0.85rem;width:140px;"></div>
+
+<div class="progress-bar"><div class="progress-fill" id="progress-fill"></div></div>
+<div class="progress-text" id="progress-text">0 / 28 completed</div>
+
+<h2>Feature 9: Measurement Tool</h2>
+<div class="fixture-ref">
+  <strong>Test files</strong> (in <code>tests/fixtures/valid/</code>):<br>
+  <code>cube.stl</code> — Clean 10mm cube<br>
+  <code>l_shape.stl</code> — Asymmetric L-shaped prism (40x30x20mm)<br>
+  <strong>Run from:</strong> <code>cd .worktrees/feat-slice-plane && .venv/bin/python -m meshscope</code>
+</div>
+<div id="feature9"></div>
+
+<h2>Feature 10: Cross-Section Slice Plane</h2>
+<div class="fixture-ref">
+  <strong>Test files:</strong> <code>cube.stl</code>, <code>l_shape.stl</code>, <code>open_box.stl</code><br>
+  Use L-shape for slice tests — asymmetric shape makes clipping direction visible.
+</div>
+<div id="feature10"></div>
+
+<div class="bugs-section">
+  <h2>Bugs Found</h2>
+  <div id="bugs-list"></div>
+  <button class="add-bug-btn" onclick="addBug()">+ Add Bug</button>
+</div>
+
+<div class="overall-notes">
+  <h2>Overall Notes</h2>
+  <textarea id="overall-notes" placeholder="Free-form observations, UX concerns, suggestions, things that felt wrong even if they technically worked..."></textarea>
+</div>
+
+<div class="export-section">
+  <button class="export-btn" onclick="exportResults()">Copy Results to Clipboard</button>
+  <div class="copy-msg" id="copy-msg">Copied! Paste into terminal or save to submissions folder.</div>
+</div>
+
+<script>
+const scenarios = [
+  // --- Feature 9: Measurement Tool ---
+  { id: 1, feature: 9, title: "Measure action disabled with no mesh",
+    steps: "1. Launch app without loading any file\n2. Check Measure button in toolbar and Edit menu",
+    expected: "Measure button and menu item are greyed out." },
+
+  { id: 2, feature: 9, title: "Toggle measure mode with M key",
+    steps: "1. Open cube.stl\n2. Press M",
+    expected: "Cursor changes to crosshair. Status bar shows 'Measure mode — click two points on mesh surface'." },
+
+  { id: 3, feature: 9, title: "Place first measurement point",
+    steps: "1. Open cube.stl, enter measure mode (M)\n2. Click on the mesh surface",
+    expected: "Colored dot appears at click point. Status bar shows 'Point A placed — click second point'." },
+
+  { id: 4, feature: 9, title: "Complete a measurement",
+    steps: "1. Continue from scenario 3\n2. Click a second point on the mesh",
+    expected: "Line drawn between points with numbered endpoints. Distance appears in Info Panel Measurements section (e.g., '10.0 mm')." },
+
+  { id: 5, feature: 9, title: "Measurement shows coordinates in info panel",
+    steps: "1. After completing a measurement\n2. Check the Measurements section in the info panel",
+    expected: "Shows: colored square, #1, distance in mm, and A/B coordinates." },
+
+  { id: 6, feature: 9, title: "Place three simultaneous measurements",
+    steps: "1. Open l_shape.stl, enter measure mode\n2. Place 3 measurements on different parts of the mesh",
+    expected: "All 3 visible with different colors (amber, blue, green). All 3 listed in info panel." },
+
+  { id: 7, feature: 9, title: "Fourth measurement replaces oldest (FIFO)",
+    steps: "1. With 3 measurements active\n2. Place a 4th measurement",
+    expected: "Oldest measurement (first placed) disappears. New one takes its color/number. Status bar mentions 'oldest measurement replaced'." },
+
+  { id: 8, feature: 9, title: "Click on empty space shows no-hit message",
+    steps: "1. In measure mode\n2. Click on empty background (not on mesh)",
+    expected: "Status bar shows 'No surface at click point'. No point placed." },
+
+  { id: 9, feature: 9, title: "Left-click does NOT orbit in measure mode",
+    steps: "1. In measure mode\n2. Left-click and drag on the mesh",
+    expected: "Mesh does NOT rotate. Left-click is consumed by measurement tool." },
+
+  { id: 10, feature: 9, title: "Right-click drag still zooms in measure mode",
+    steps: "1. In measure mode\n2. Right-click and drag",
+    expected: "Camera zooms in/out normally." },
+
+  { id: 11, feature: 9, title: "Scroll wheel still works in measure mode",
+    steps: "1. In measure mode\n2. Scroll mouse wheel",
+    expected: "Camera zooms in/out normally." },
+
+  { id: 12, feature: 9, title: "Exit measure mode with M key",
+    steps: "1. In measure mode\n2. Press M again",
+    expected: "Cursor returns to arrow. Status bar shows mesh info. Measurements remain visible." },
+
+  { id: 13, feature: 9, title: "Exit measure mode discards pending point",
+    steps: "1. Enter measure mode, place point A (one click)\n2. Press M to exit before placing point B",
+    expected: "Pending point A marker disappears. No measurement created." },
+
+  { id: 14, feature: 9, title: "Clear Measurements from Edit menu",
+    steps: "1. Place 1-2 measurements\n2. Edit > Clear Measurements",
+    expected: "All measurement lines and info panel entries removed. Status bar shows 'Measurements cleared'." },
+
+  { id: 15, feature: 9, title: "Measurements cleared on transform",
+    steps: "1. Place a measurement\n2. Ctrl+T, scale by 2x, OK",
+    expected: "Measurements cleared. Status bar mentions 'Measurements cleared — mesh geometry changed'." },
+
+  { id: 16, feature: 9, title: "Measurements cleared on undo",
+    steps: "1. Scale mesh, place measurement, then Ctrl+Z (undo scale)",
+    expected: "Measurements cleared when mesh geometry changes via undo." },
+
+  { id: 17, feature: 9, title: "Measure action enabled after file load",
+    steps: "1. Open cube.stl\n2. Check Measure button",
+    expected: "Measure button is enabled." },
+
+  // --- Feature 10: Cross-Section Slice Plane ---
+  { id: 18, feature: 10, title: "Slice action disabled with no mesh",
+    steps: "1. Launch app without loading any file\n2. Check for Slice button in toolbar and View menu",
+    expected: "Slice button and menu item are greyed out." },
+
+  { id: 19, feature: 10, title: "Toggle slice mode with C key",
+    steps: "1. Open l_shape.stl\n2. Press C",
+    expected: "Translucent plane appears through model center. Floating overlay panel appears top-right with X/Y/Z and Reset buttons. Status bar shows slice message." },
+
+  { id: 20, feature: 10, title: "Drag plane to move",
+    steps: "1. Activate slice (C)\n2. Grab the center handle of the plane and drag",
+    expected: "Plane moves along its normal. Mesh clips in real-time as you drag. Cross-section shows terracotta fill color." },
+
+  { id: 21, feature: 10, title: "Rotate plane with edge handles",
+    steps: "1. With slice active\n2. Grab an edge/rotation handle and drag to tilt the plane",
+    expected: "Plane rotates to arbitrary angle. Clip updates in real-time." },
+
+  { id: 22, feature: 10, title: "X preset button",
+    steps: "1. With slice active\n2. Click X button in floating overlay",
+    expected: "Plane snaps to YZ plane through model center (normal along X axis). Status bar shows 'Slice plane: X axis'." },
+
+  { id: 23, feature: 10, title: "Y preset button",
+    steps: "1. Click Y button in overlay",
+    expected: "Plane snaps to XZ plane through model center." },
+
+  { id: 24, feature: 10, title: "Z preset button",
+    steps: "1. Click Z button in overlay",
+    expected: "Plane snaps to XY plane through model center." },
+
+  { id: 25, feature: 10, title: "Reset button",
+    steps: "1. Drag plane away from center\n2. Click Reset in overlay",
+    expected: "Plane returns to model center at current orientation. Status bar shows 'Slice plane reset to model center'." },
+
+  { id: 26, feature: 10, title: "Exit slice mode with Escape",
+    steps: "1. With slice active\n2. Press Escape",
+    expected: "Plane removed. Full mesh restored. Overlay panel hidden." },
+
+  { id: 27, feature: 10, title: "Slice persists through transform",
+    steps: "1. Open l_shape.stl, activate slice (C)\n2. Scale mesh 2x (Ctrl+T)",
+    expected: "Plane stays at world-space position. Clip recalculated on larger mesh." },
+
+  { id: 28, feature: 10, title: "Slice removed on new file load",
+    steps: "1. Activate slice on l_shape.stl\n2. Open cube.stl (Ctrl+O)",
+    expected: "Slice plane removed. Cube displayed normally without clipping." },
+];
+
+function renderScenarios() {
+  const f9 = document.getElementById('feature9');
+  const f10 = document.getElementById('feature10');
+  scenarios.forEach(s => {
+    const container = s.feature === 9 ? f9 : f10;
+    container.innerHTML += '<div class="scenario" id="scenario-' + s.id + '">' +
+      '<div class="scenario-header">' +
+        '<span class="scenario-num">' + s.id + '</span>' +
+        '<span class="scenario-title">' + s.title + '</span>' +
+        '<button class="toggle-details" onclick="toggleDetails(' + s.id + ')">details</button>' +
+        '<div class="btn-group">' +
+          '<button class="btn pass-btn" onclick="setResult(' + s.id + ',\'pass\',this)">Pass</button>' +
+          '<button class="btn fail-btn" onclick="setResult(' + s.id + ',\'fail\',this)">Fail</button>' +
+          '<button class="btn skip-btn" onclick="setResult(' + s.id + ',\'skip\',this)">Skip</button>' +
+        '</div>' +
+      '</div>' +
+      '<div class="scenario-details" id="details-' + s.id + '">' +
+        '<div class="steps"><strong>Steps:</strong><br>' + s.steps.replace(/\n/g,'<br>') + '</div>' +
+        '<div class="steps"><strong>Expected:</strong><br>' + s.expected + '</div>' +
+      '</div>' +
+      '<div class="scenario-notes">' +
+        '<textarea class="notes-input" id="notes-' + s.id + '" placeholder="Notes — observations, issues, anything worth recording"></textarea>' +
+      '</div>' +
+    '</div>';
+  });
+}
+
+const results = {};
+
+function setResult(id, result, btn) {
+  results[id] = result;
+  const sc = document.getElementById('scenario-' + id);
+  sc.className = 'scenario ' + (result === 'skip' ? '' : result);
+  sc.querySelectorAll('.btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  updateProgress();
+}
+
+function toggleDetails(id) {
+  document.getElementById('details-' + id).classList.toggle('open');
+}
+
+function updateProgress() {
+  const done = Object.keys(results).length;
+  const pct = (done / scenarios.length * 100).toFixed(0);
+  document.getElementById('progress-fill').style.width = pct + '%';
+  document.getElementById('progress-text').textContent = done + ' / ' + scenarios.length + ' completed';
+}
+
+var bugCount = 0;
+function addBug() {
+  bugCount++;
+  var n = bugCount;
+  document.getElementById('bugs-list').innerHTML +=
+    '<div class="bug-entry" id="bug-' + n + '">' +
+      '<button class="remove-bug" onclick="document.getElementById(\'bug-' + n + '\').remove()">remove</button>' +
+      '<div class="bug-row">' +
+        '<div class="bug-field"><label>Severity</label><select id="bug-sev-' + n + '">' +
+          '<option>SEV-1 (crash/data loss)</option><option>SEV-2 (broken, workaround exists)</option>' +
+          '<option selected>SEV-3 (minor UX)</option><option>SEV-4 (polish/enhancement)</option>' +
+        '</select></div>' +
+        '<div class="bug-field"><label>Feature</label><select id="bug-feat-' + n + '">' +
+          '<option>9 - Measurement Tool</option><option>10 - Cross-Section Slice Plane</option>' +
+        '</select></div>' +
+      '</div>' +
+      '<div class="bug-field"><label>Description</label><input id="bug-desc-' + n + '" placeholder="What went wrong?"></div>' +
+      '<div class="bug-field" style="margin-top:8px"><label>Steps to Reproduce</label><textarea id="bug-steps-' + n + '" placeholder="1. ...\n2. ...\n3. ..."></textarea></div>' +
+      '<div class="bug-field" style="margin-top:8px"><label>Expected vs Actual</label><textarea id="bug-exp-' + n + '" placeholder="Expected: ...\nActual: ..."></textarea></div>' +
+    '</div>';
+}
+
+function exportResults() {
+  var tester = document.getElementById('tester-name').value || 'Unknown';
+  var md = '# UAT Session 5 Results\n\n';
+  md += '**Date:** 2026-04-08\n';
+  md += '**Tester:** ' + tester + '\n';
+  md += '**Features:** Measurement Tool, Cross-Section Slice Plane\n\n';
+
+  var pass = 0, fail = 0, skip = 0;
+  for (var k in results) {
+    if (results[k] === 'pass') pass++;
+    else if (results[k] === 'fail') fail++;
+    else if (results[k] === 'skip') skip++;
+  }
+  var untested = scenarios.length - Object.keys(results).length;
+  md += '**Summary:** ' + pass + ' passed, ' + fail + ' failed, ' + skip + ' skipped, ' + untested + ' not tested\n\n---\n\n';
+
+  md += '## Scenarios\n\n';
+  md += '| # | Scenario | Result | Notes |\n';
+  md += '|---|---|---|---|\n';
+  scenarios.forEach(function(s) {
+    var r = results[s.id] || 'not tested';
+    var icon = r === 'pass' ? 'PASS' : r === 'fail' ? 'FAIL' : r === 'skip' ? 'SKIP' : '-';
+    var el = document.getElementById('notes-' + s.id);
+    var notes = el ? el.value.replace(/\|/g, '/').replace(/\n/g, ' ') : '';
+    md += '| ' + s.id + ' | ' + s.title + ' | ' + icon + ' | ' + notes + ' |\n';
+  });
+
+  var bugEntries = document.querySelectorAll('.bug-entry');
+  if (bugEntries.length > 0) {
+    md += '\n---\n\n## Bugs Found\n\n';
+    var i = 0;
+    bugEntries.forEach(function(el) {
+      i++;
+      var id = el.id.split('-')[1];
+      var sev = document.getElementById('bug-sev-' + id);
+      var feat = document.getElementById('bug-feat-' + id);
+      var desc = document.getElementById('bug-desc-' + id);
+      var steps = document.getElementById('bug-steps-' + id);
+      var exp = document.getElementById('bug-exp-' + id);
+      md += '### Bug ' + i + '\n';
+      md += '- **Severity:** ' + (sev ? sev.value : '') + '\n';
+      md += '- **Feature:** ' + (feat ? feat.value : '') + '\n';
+      md += '- **Description:** ' + (desc ? desc.value : '') + '\n';
+      md += '- **Steps:** ' + (steps ? steps.value.replace(/\n/g, '; ') : '') + '\n';
+      md += '- **Expected vs Actual:** ' + (exp ? exp.value.replace(/\n/g, '; ') : '') + '\n\n';
+    });
+  }
+
+  var overall = document.getElementById('overall-notes').value;
+  if (overall) {
+    md += '\n---\n\n## Overall Notes\n\n' + overall + '\n';
+  }
+
+  navigator.clipboard.writeText(md).then(function() {
+    var msg = document.getElementById('copy-msg');
+    msg.style.display = 'block';
+    setTimeout(function() { msg.style.display = 'none'; }, 3000);
+  });
+}
+
+renderScenarios();
+</script>
+</body>
+</html>

--- a/tests/ui/test_measurement_mode.py
+++ b/tests/ui/test_measurement_mode.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 
 import pytest
-from PySide6.QtGui import QKeySequence
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QKeySequence, QMouseEvent
 from PySide6.QtWidgets import QApplication
 
 from meshscope.core.mesh_data import Measurement
@@ -231,6 +232,40 @@ class TestMainWindowMeasureMode:
         non_mouse_event = QEvent(QEvent.Type.FocusIn)
         result = window.eventFilter(window._viewport.vtk_interactor, non_mouse_event)
         assert result is False
+
+    def test_event_filter_consumes_left_press(self, window: MainWindow) -> None:
+        """Regression: left-click press must be consumed to prevent VTK orbit."""
+        from PySide6.QtCore import QPointF
+
+        fixtures = Path(__file__).parent.parent / "fixtures" / "valid"
+        window._load_file(fixtures / "cube.stl")
+        window.measure_action.setChecked(True)
+        press = QMouseEvent(
+            QMouseEvent.Type.MouseButtonPress,
+            QPointF(100, 100),
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        result = window.eventFilter(window._viewport.vtk_interactor, press)
+        assert result is True  # consumed, not forwarded to VTK
+
+    def test_event_filter_passes_right_press(self, window: MainWindow) -> None:
+        """Regression: right-click must pass through for VTK zoom."""
+        from PySide6.QtCore import QPointF
+
+        fixtures = Path(__file__).parent.parent / "fixtures" / "valid"
+        window._load_file(fixtures / "cube.stl")
+        window.measure_action.setChecked(True)
+        press = QMouseEvent(
+            QMouseEvent.Type.MouseButtonPress,
+            QPointF(100, 100),
+            Qt.MouseButton.RightButton,
+            Qt.MouseButton.RightButton,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        result = window.eventFilter(window._viewport.vtk_interactor, press)
+        assert result is False  # passed through to VTK
 
 
 class TestMainWindowClearMeasurements:

--- a/tests/ui/test_slice_mode.py
+++ b/tests/ui/test_slice_mode.py
@@ -3,6 +3,7 @@
 import pytest
 from PySide6.QtWidgets import QApplication, QPushButton
 
+from meshscope.ui.main_window import MainWindow
 from meshscope.ui.slice_overlay import SliceOverlayWidget
 from meshscope.ui.viewport_widget import ViewportWidget
 
@@ -141,3 +142,33 @@ class TestViewportWidgetSliceOverlay:
         vp = ViewportWidget()
         assert vp.slice_overlay.parent() is vp
         vp.close()
+
+
+@pytest.fixture()
+def window(qapp: QApplication) -> MainWindow:
+    w = MainWindow()
+    yield w
+    w.close()
+
+
+class TestMainWindowSliceAction:
+    def test_has_slice_action(self, window: MainWindow) -> None:
+        assert window.slice_action is not None
+
+    def test_slice_action_is_checkable(self, window: MainWindow) -> None:
+        assert window.slice_action.isCheckable()
+
+    def test_slice_action_disabled_initially(self, window: MainWindow) -> None:
+        assert not window.slice_action.isEnabled()
+
+    def test_slice_action_shortcut_is_c(self, window: MainWindow) -> None:
+        assert window.slice_action.shortcut().toString() == "C"
+
+    def test_slice_action_enabled_after_load(self, window: MainWindow) -> None:
+        window._set_state_success("test.stl", 1000)
+        assert window.slice_action.isEnabled()
+
+    def test_slice_action_disabled_after_error(self, window: MainWindow) -> None:
+        window._set_state_success("test.stl", 1000)
+        window._set_state_error("File corrupt")
+        assert not window.slice_action.isEnabled()

--- a/tests/ui/test_slice_mode.py
+++ b/tests/ui/test_slice_mode.py
@@ -4,6 +4,7 @@ import pytest
 from PySide6.QtWidgets import QApplication, QPushButton
 
 from meshscope.ui.slice_overlay import SliceOverlayWidget
+from meshscope.ui.viewport_widget import ViewportWidget
 
 
 @pytest.fixture()
@@ -123,3 +124,20 @@ class TestSliceOverlayWidgetVisibility:
         widget.hide_overlay()
         assert not widget.isVisible()
         widget.close()
+
+
+class TestViewportWidgetSliceOverlay:
+    def test_has_slice_overlay(self, qapp: QApplication) -> None:
+        vp = ViewportWidget()
+        assert vp.slice_overlay is not None
+        vp.close()
+
+    def test_slice_overlay_initially_hidden(self, qapp: QApplication) -> None:
+        vp = ViewportWidget()
+        assert not vp.slice_overlay.isVisible()
+        vp.close()
+
+    def test_slice_overlay_is_child_of_viewport(self, qapp: QApplication) -> None:
+        vp = ViewportWidget()
+        assert vp.slice_overlay.parent() is vp
+        vp.close()

--- a/tests/ui/test_slice_mode.py
+++ b/tests/ui/test_slice_mode.py
@@ -1,0 +1,125 @@
+"""Tests for slice mode UI: SliceOverlayWidget and MainWindow integration."""
+
+import pytest
+from PySide6.QtWidgets import QApplication, QPushButton
+
+from meshscope.ui.slice_overlay import SliceOverlayWidget
+
+
+@pytest.fixture()
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class TestSliceOverlayWidgetConstruction:
+    def test_creates_without_parent(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        assert widget is not None
+        widget.close()
+
+    def test_has_preset_buttons(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        x_btn = widget.findChild(QPushButton, "btn_x")
+        y_btn = widget.findChild(QPushButton, "btn_y")
+        z_btn = widget.findChild(QPushButton, "btn_z")
+        assert x_btn is not None
+        assert y_btn is not None
+        assert z_btn is not None
+        widget.close()
+
+    def test_has_reset_button(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        reset_btn = widget.findChild(QPushButton, "btn_reset")
+        assert reset_btn is not None
+        widget.close()
+
+    def test_initially_hidden(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        assert not widget.isVisible()
+        widget.close()
+
+
+class TestSliceOverlayWidgetSignals:
+    def test_x_button_emits_preset_signal(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        received: list[str] = []
+        widget.preset_clicked.connect(lambda axis: received.append(axis))
+
+        x_btn = widget.findChild(QPushButton, "btn_x")
+        x_btn.click()
+        assert received == ["x"]
+        widget.close()
+
+    def test_y_button_emits_preset_signal(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        received: list[str] = []
+        widget.preset_clicked.connect(lambda axis: received.append(axis))
+
+        y_btn = widget.findChild(QPushButton, "btn_y")
+        y_btn.click()
+        assert received == ["y"]
+        widget.close()
+
+    def test_z_button_emits_preset_signal(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        received: list[str] = []
+        widget.preset_clicked.connect(lambda axis: received.append(axis))
+
+        z_btn = widget.findChild(QPushButton, "btn_z")
+        z_btn.click()
+        assert received == ["z"]
+        widget.close()
+
+    def test_reset_button_emits_reset_signal(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        received: list[bool] = []
+        widget.reset_clicked.connect(lambda: received.append(True))
+
+        reset_btn = widget.findChild(QPushButton, "btn_reset")
+        reset_btn.click()
+        assert received == [True]
+        widget.close()
+
+
+class TestSliceOverlayWidgetActivePreset:
+    def test_set_active_preset_x(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        widget.set_active_preset("x")
+        x_btn = widget.findChild(QPushButton, "btn_x")
+        assert x_btn.property("active") is True
+        widget.close()
+
+    def test_set_active_preset_clears_others(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        widget.set_active_preset("x")
+        y_btn = widget.findChild(QPushButton, "btn_y")
+        z_btn = widget.findChild(QPushButton, "btn_z")
+        assert y_btn.property("active") is not True
+        assert z_btn.property("active") is not True
+        widget.close()
+
+    def test_set_active_preset_none_clears_all(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        widget.set_active_preset("x")
+        widget.set_active_preset(None)
+        x_btn = widget.findChild(QPushButton, "btn_x")
+        assert x_btn.property("active") is not True
+        widget.close()
+
+
+class TestSliceOverlayWidgetVisibility:
+    def test_show_overlay(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        widget.show_overlay()
+        assert widget.isVisible()
+        widget.close()
+
+    def test_hide_overlay(self, qapp: QApplication) -> None:
+        widget = SliceOverlayWidget(None)
+        widget.show_overlay()
+        widget.hide_overlay()
+        assert not widget.isVisible()
+        widget.close()

--- a/tests/ui/test_slice_mode.py
+++ b/tests/ui/test_slice_mode.py
@@ -172,3 +172,22 @@ class TestMainWindowSliceAction:
         window._set_state_success("test.stl", 1000)
         window._set_state_error("File corrupt")
         assert not window.slice_action.isEnabled()
+
+    def test_slice_activates_with_loaded_mesh(self, window: MainWindow) -> None:
+        """Regression: slice must activate when interactor is passed directly."""
+        from pathlib import Path
+
+        fixtures = Path(__file__).parent.parent / "fixtures" / "valid"
+        window._load_file(fixtures / "cube.stl")
+        window.slice_action.setChecked(True)
+        assert window._viewport.scene_manager.slice_active is True
+
+    def test_slice_deactivates_on_uncheck(self, window: MainWindow) -> None:
+        """Regression: slice must deactivate cleanly."""
+        from pathlib import Path
+
+        fixtures = Path(__file__).parent.parent / "fixtures" / "valid"
+        window._load_file(fixtures / "cube.stl")
+        window.slice_action.setChecked(True)
+        window.slice_action.setChecked(False)
+        assert window._viewport.scene_manager.slice_active is False

--- a/tests/unit/test_scene_manager.py
+++ b/tests/unit/test_scene_manager.py
@@ -353,3 +353,87 @@ class TestSceneManagerPrintBed:
         sm.show_print_bed(220, 220, 250, bbox)
         sm.clear()
         assert sm.print_bed_visible is False
+
+
+class TestSceneManagerSlicePlane:
+    def test_slice_not_active_initially(self) -> None:
+        renderer = vtkRenderer()
+        sm = SceneManager(renderer)
+        assert sm.slice_active is False
+
+    def test_activate_slice_plane(self) -> None:
+        from unittest.mock import MagicMock
+
+        renderer = vtkRenderer()
+        sm = SceneManager(renderer)
+        sm.display_mesh(_make_polydata())
+
+        interactor = MagicMock()
+        sm.activate_slice_plane(interactor)
+        assert sm.slice_active is True
+
+    def test_deactivate_slice_plane(self) -> None:
+        from unittest.mock import MagicMock
+
+        renderer = vtkRenderer()
+        sm = SceneManager(renderer)
+        sm.display_mesh(_make_polydata())
+
+        interactor = MagicMock()
+        sm.activate_slice_plane(interactor)
+        sm.deactivate_slice_plane()
+        assert sm.slice_active is False
+
+    def test_activate_without_mesh_is_noop(self) -> None:
+        from unittest.mock import MagicMock
+
+        renderer = vtkRenderer()
+        sm = SceneManager(renderer)
+        interactor = MagicMock()
+        sm.activate_slice_plane(interactor)
+        assert sm.slice_active is False
+
+    def test_clear_deactivates_slice(self) -> None:
+        from unittest.mock import MagicMock
+
+        renderer = vtkRenderer()
+        sm = SceneManager(renderer)
+        sm.display_mesh(_make_polydata())
+
+        interactor = MagicMock()
+        sm.activate_slice_plane(interactor)
+        sm.clear()
+        assert sm.slice_active is False
+
+    def test_set_slice_preset(self) -> None:
+        from unittest.mock import MagicMock
+
+        renderer = vtkRenderer()
+        sm = SceneManager(renderer)
+        sm.display_mesh(_make_polydata())
+
+        interactor = MagicMock()
+        sm.activate_slice_plane(interactor)
+        sm.set_slice_preset("x")  # must not raise
+
+    def test_reset_slice_plane(self) -> None:
+        from unittest.mock import MagicMock
+
+        renderer = vtkRenderer()
+        sm = SceneManager(renderer)
+        sm.display_mesh(_make_polydata())
+
+        interactor = MagicMock()
+        sm.activate_slice_plane(interactor)
+        sm.reset_slice_plane()  # must not raise
+
+    def test_update_slice_mesh(self) -> None:
+        from unittest.mock import MagicMock
+
+        renderer = vtkRenderer()
+        sm = SceneManager(renderer)
+        sm.display_mesh(_make_polydata())
+
+        interactor = MagicMock()
+        sm.activate_slice_plane(interactor)
+        sm.update_slice_mesh(_make_polydata())  # must not raise

--- a/tests/unit/test_slice_plane.py
+++ b/tests/unit/test_slice_plane.py
@@ -157,3 +157,106 @@ class TestSlicePlaneManagerActivation:
         mgr.activate(polydata, bounds)
         count_after_second = renderer.GetActors().GetNumberOfItems()
         assert count_after_second == count_after_first
+
+
+class TestSlicePlaneManagerPresets:
+    def test_set_preset_x(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+
+        mgr.set_preset("x", bounds)
+        assert mgr.current_preset == "x"
+
+    def test_set_preset_y(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+
+        mgr.set_preset("y", bounds)
+        assert mgr.current_preset == "y"
+
+    def test_set_preset_z(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+
+        mgr.set_preset("z", bounds)
+        assert mgr.current_preset == "z"
+
+    def test_preset_when_inactive_is_noop(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        mgr.set_preset("x", (-5, 5, -5, 5, -5, 5))  # must not raise
+        assert mgr.is_active is False
+
+    def test_preset_invalid_axis_ignored(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+
+        mgr.set_preset("q", bounds)  # invalid axis
+        # Should still be at the default Z preset
+        assert mgr.current_preset == "z"
+
+
+class TestSlicePlaneManagerReset:
+    def test_reset_keeps_orientation(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+
+        mgr.set_preset("x", bounds)
+        assert mgr.current_preset == "x"
+
+        mgr.reset_to_center(bounds)
+        # Preset should still be "x" since reset keeps orientation
+        # (current_preset is only cleared on manual drag)
+        assert mgr.current_preset == "x"
+
+    def test_reset_when_inactive_is_noop(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        mgr.reset_to_center((-5, 5, -5, 5, -5, 5))  # must not raise
+        assert mgr.is_active is False
+
+
+class TestSlicePlaneManagerMeshUpdate:
+    def test_update_mesh_recalculates_clip(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+
+        mgr.update_mesh(polydata, bounds)
+        actors_after = renderer.GetActors().GetNumberOfItems()
+        # Should still have actors (clip recalculated, not removed)
+        assert actors_after >= 1
+
+    def test_update_mesh_when_inactive_is_noop(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.update_mesh(polydata, bounds)  # must not raise
+        assert mgr.is_active is False

--- a/tests/unit/test_slice_plane.py
+++ b/tests/unit/test_slice_plane.py
@@ -260,3 +260,72 @@ class TestSlicePlaneManagerMeshUpdate:
         bounds = polydata.GetBounds()
         mgr.update_mesh(polydata, bounds)  # must not raise
         assert mgr.is_active is False
+
+
+class TestSlicePlaneManagerInteraction:
+    def test_on_interaction_clears_preset(self) -> None:
+        """When user manually drags the widget, preset should be cleared."""
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+
+        assert mgr.current_preset == "z"
+
+        # Simulate what the widget callback does.
+        # With a mock interactor, the widget is not created,
+        # so _on_interaction will return early (guard clause).
+        mgr._on_interaction(None, "InteractionEvent")
+
+    def test_activate_default_is_z_preset(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+        assert mgr.current_preset == "z"
+
+    def test_preset_after_deactivate_resets_to_z_on_reactivate(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+
+        mgr.activate(polydata, bounds)
+        mgr.set_preset("x", bounds)
+        assert mgr.current_preset == "x"
+
+        mgr.deactivate()
+        mgr.activate(polydata, bounds)
+        assert mgr.current_preset == "z"  # reset to default on reactivate
+
+
+class TestSlicePlaneManagerEdgeCases:
+    def test_activate_with_degenerate_polydata(self) -> None:
+        """Single triangle (non-manifold) should not crash."""
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_triangle_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+        assert mgr.is_active is True
+
+    def test_activate_deactivate_cycle(self) -> None:
+        """Repeated activate/deactivate should not leak actors."""
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+
+        for _ in range(5):
+            mgr.activate(polydata, bounds)
+            mgr.deactivate()
+
+        assert mgr.is_active is False
+        assert renderer.GetActors().GetNumberOfItems() == 0

--- a/tests/unit/test_slice_plane.py
+++ b/tests/unit/test_slice_plane.py
@@ -1,0 +1,159 @@
+"""Tests for SlicePlaneManager — clipping pipeline and plane widget management."""
+
+from unittest.mock import MagicMock
+
+from vtkmodules.vtkCommonCore import vtkFloatArray, vtkPoints
+from vtkmodules.vtkCommonDataModel import vtkCellArray, vtkPolyData, vtkTriangle
+from vtkmodules.vtkRenderingCore import vtkRenderer
+
+from meshscope.vtk_adapter.slice_plane_manager import SlicePlaneManager
+
+
+def _make_cube_polydata() -> vtkPolyData:
+    """Create a simple cube polydata (12 triangles) for clipping tests.
+
+    A proper closed surface is needed for vtkClipClosedSurface to generate caps.
+    """
+    points = vtkPoints()
+    # 8 vertices of a unit cube centered at origin
+    coords = [
+        (-5, -5, -5),
+        (5, -5, -5),
+        (5, 5, -5),
+        (-5, 5, -5),
+        (-5, -5, 5),
+        (5, -5, 5),
+        (5, 5, 5),
+        (-5, 5, 5),
+    ]
+    for c in coords:
+        points.InsertNextPoint(*c)
+
+    cells = vtkCellArray()
+    # 12 triangles forming 6 faces of the cube
+    faces = [
+        (0, 1, 2),
+        (0, 2, 3),  # bottom (-Z)
+        (4, 6, 5),
+        (4, 7, 6),  # top (+Z)
+        (0, 4, 5),
+        (0, 5, 1),  # front (-Y)
+        (2, 6, 7),
+        (2, 7, 3),  # back (+Y)
+        (0, 3, 7),
+        (0, 7, 4),  # left (-X)
+        (1, 5, 6),
+        (1, 6, 2),  # right (+X)
+    ]
+    for f in faces:
+        tri = vtkTriangle()
+        tri.GetPointIds().SetId(0, f[0])
+        tri.GetPointIds().SetId(1, f[1])
+        tri.GetPointIds().SetId(2, f[2])
+        cells.InsertNextCell(tri)
+
+    normals = vtkFloatArray()
+    normals.SetNumberOfComponents(3)
+    normals.SetName("Normals")
+    for _ in faces:
+        normals.InsertNextTuple3(0, 0, 1)
+
+    polydata = vtkPolyData()
+    polydata.SetPoints(points)
+    polydata.SetPolys(cells)
+    polydata.GetCellData().SetNormals(normals)
+    return polydata
+
+
+def _make_triangle_polydata() -> vtkPolyData:
+    """Create a minimal single-triangle polydata for basic tests."""
+    points = vtkPoints()
+    points.InsertNextPoint(0, 0, 0)
+    points.InsertNextPoint(10, 0, 0)
+    points.InsertNextPoint(5, 10, 0)
+
+    cells = vtkCellArray()
+    tri = vtkTriangle()
+    tri.GetPointIds().SetId(0, 0)
+    tri.GetPointIds().SetId(1, 1)
+    tri.GetPointIds().SetId(2, 2)
+    cells.InsertNextCell(tri)
+
+    polydata = vtkPolyData()
+    polydata.SetPoints(points)
+    polydata.SetPolys(cells)
+    return polydata
+
+
+class TestSlicePlaneManagerConstruction:
+    def test_initial_state_is_inactive(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        assert mgr.is_active is False
+
+    def test_no_actors_initially(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        SlicePlaneManager(renderer, interactor)
+        assert renderer.GetActors().GetNumberOfItems() == 0
+
+
+class TestSlicePlaneManagerActivation:
+    def test_activate_sets_active(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+        assert mgr.is_active is True
+
+    def test_activate_adds_actors_to_renderer(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+        # At least the clipped mesh actor should be added
+        assert renderer.GetActors().GetNumberOfItems() >= 1
+
+    def test_deactivate_sets_inactive(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+        mgr.deactivate()
+        assert mgr.is_active is False
+
+    def test_deactivate_removes_actors(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+        mgr.deactivate()
+        assert renderer.GetActors().GetNumberOfItems() == 0
+
+    def test_deactivate_when_inactive_is_noop(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        mgr.deactivate()  # must not raise
+        assert mgr.is_active is False
+
+    def test_double_activate_does_not_duplicate_actors(self) -> None:
+        renderer = vtkRenderer()
+        interactor = MagicMock()
+        mgr = SlicePlaneManager(renderer, interactor)
+        polydata = _make_cube_polydata()
+        bounds = polydata.GetBounds()
+        mgr.activate(polydata, bounds)
+        count_after_first = renderer.GetActors().GetNumberOfItems()
+        mgr.activate(polydata, bounds)
+        count_after_second = renderer.GetActors().GetNumberOfItems()
+        assert count_after_second == count_after_first


### PR DESCRIPTION
## Summary
- **Feature 10 — Cross-Section Slice Plane**: Interactive clipping plane with vtkImplicitPlaneWidget2, floating overlay with X/Y/Z presets and Reset, terracotta interior fill, C key toggle
- **Feature 9 — Measurement Tool fixes**: Left-click now consumed in measure mode (prevents VTK orbit), isinstance type narrowing for mypy, overlay sizing fixes
- **UAT Session 5**: 28/28 scenarios passing across both features

## Feature 10 Implementation
- `SlicePlaneManager` — VTK clipping pipeline with vtkClipClosedSurface + vtkClipPolyData fallback
- `SliceOverlayWidget` — floating Qt panel with preset buttons and dark theme
- `SceneManager` — delegation methods for activate/deactivate/preset/reset/update
- `MainWindow` — C key toggle, Escape via QShortcut, overlay signals, mesh update hooks
- `PROJECT_BIBLE.md` — added `--include-module=vtkmodules.vtkInteractionWidgets`

## Feature 9 Fixes (from UAT testing)
- eventFilter consumes left press/move/release to prevent VTK orbit in measure mode
- isinstance(event, QMouseEvent) type narrowing for mypy
- Right-click drag and scroll still work for navigation

## Test plan
- [x] 549 tests pass (56 new), 0 failures
- [x] UAT Session 5: 28/28 scenarios passing
- [x] Manual test: measurement tool click-to-place works without orbit
- [x] Manual test: slice plane activates, presets work, overlay visible
- [x] Manual test: Escape exits slice mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)