### PR TITLE
fix(tests): stop VTK render-window tests segfaulting; run them on Linux under xvfb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,15 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1-mesa-dev libxkbcommon0
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            libegl1 libgl1 libgl1-mesa-dev libgl1-mesa-dri libglx-mesa0 \
+            libxkbcommon0 libxkbcommon-x11-0 libdbus-1-3 \
+            libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+            libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 \
+            libxcb-xkb1
 
       - name: Install dependencies
         run: pip install -r requirements.txt && pip install -e . --no-deps
@@ -75,7 +83,24 @@ jobs:
       - name: Install dev tools
         run: pip install pytest pytest-qt
 
-      - name: Run tests
+      # QVTKRenderWindowInteractor hands QWidget.winId() to
+      # vtkRenderWindow.SetWindowInfo(), which casts it to a native pointer and
+      # dereferences it. The offscreen QPA plugin returns synthetic handles, so
+      # that cast segfaults. Linux therefore gets a real X server (xvfb) plus
+      # software GL (llvmpipe) and runs the full suite, render-window tests
+      # included. See tests/ui/_native_window.py.
+      - name: Run tests (Linux, virtual display)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: xvfb-run -a pytest || [ $? -eq 5 ]
+        env:
+          LIBGL_ALWAYS_SOFTWARE: '1'
+
+      # macOS and Windows runners provide no GL context usable by VTK, so they
+      # run headless; the render-window tests skip themselves rather than crash.
+      - name: Run tests (macOS/Windows, offscreen)
+        if: runner.os != 'Linux'
+        shell: bash
         run: pytest || [ $? -eq 5 ]
         env:
           QT_QPA_PLATFORM: offscreen

--- a/tests/ui/_native_window.py
+++ b/tests/ui/_native_window.py
@@ -1,0 +1,48 @@
+"""Detection of whether Qt can supply a real native window handle.
+
+``QVTKRenderWindowInteractor.__init__`` passes ``QWidget.winId()`` straight into
+``vtkRenderWindow.SetWindowInfo()``. Once ``vtkmodules.vtkRenderingOpenGL2`` is
+imported -- which ``meshscope.ui.viewport_widget`` does, to enable rendering --
+the VTK object factory returns a platform render window (``vtkCocoaRenderWindow``,
+``vtkWin32OpenGLRenderWindow``, ``vtkXOpenGLRenderWindow``). Those classes cast the
+value handed to ``SetWindowInfo`` into a native pointer (``NSView*``, ``HWND``,
+``Window``) and dereference it.
+
+The ``offscreen`` and ``minimal`` QPA plugins do not create native windows; their
+``winId()`` returns a small synthetic counter (1, 2, 4, ...). Casting that to a
+pointer and dereferencing it segfaults the interpreter -- no Python exception is
+raised, so it cannot be caught with ``try``/``except``.
+
+Tests that build a VTK render window therefore need a real display. Detect that
+up front and skip, rather than crashing the whole session.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# QPA plugins that report synthetic, non-dereferenceable window handles.
+_HANDLE_LESS_PLATFORMS = frozenset({"offscreen", "minimal", "vnc"})
+
+
+def has_native_window() -> bool:
+    """Return True when Qt can hand VTK a dereferenceable native window handle."""
+    platform = os.environ.get("QT_QPA_PLATFORM", "").strip().lower()
+    if platform in _HANDLE_LESS_PLATFORMS:
+        return False
+    if sys.platform.startswith("linux"):
+        # An X11/Wayland server must be reachable; xvfb-run supplies one.
+        return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    return True
+
+
+requires_native_window = pytest.mark.skipif(
+    not has_native_window(),
+    reason=(
+        "needs a native window handle: QVTKRenderWindowInteractor segfaults when "
+        "QT_QPA_PLATFORM=offscreen. Run under a real display (e.g. xvfb-run)."
+    ),
+)

--- a/tests/ui/test_file_loading.py
+++ b/tests/ui/test_file_loading.py
@@ -9,6 +9,13 @@ from PySide6.QtWidgets import QApplication
 
 from meshscope.ui.main_window import MainWindow
 
+from ._native_window import requires_native_window
+
+# These tests construct MainWindow/ViewportWidget, which build a VTK render
+# window from QWidget.winId(). That handle is not dereferenceable under the
+# offscreen QPA plugin, so the process segfaults instead of raising.
+pytestmark = requires_native_window
+
 FIXTURES = Path(__file__).parent.parent / "fixtures"
 VALID = FIXTURES / "valid"
 INVALID = FIXTURES / "invalid"

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -9,6 +9,13 @@ from PySide6.QtWidgets import QApplication, QComboBox
 from meshscope.ui.info_panel import InfoPanel
 from meshscope.ui.main_window import MainWindow
 
+from ._native_window import requires_native_window
+
+# These tests construct MainWindow/ViewportWidget, which build a VTK render
+# window from QWidget.winId(). That handle is not dereferenceable under the
+# offscreen QPA plugin, so the process segfaults instead of raising.
+pytestmark = requires_native_window
+
 
 @pytest.fixture()
 def window(qapp: QApplication) -> MainWindow:

--- a/tests/ui/test_measurement_mode.py
+++ b/tests/ui/test_measurement_mode.py
@@ -11,6 +11,13 @@ from meshscope.core.mesh_data import Measurement
 from meshscope.ui.info_panel import InfoPanel
 from meshscope.ui.main_window import MainWindow
 
+from ._native_window import requires_native_window
+
+# These tests construct MainWindow/ViewportWidget, which build a VTK render
+# window from QWidget.winId(). That handle is not dereferenceable under the
+# offscreen QPA plugin, so the process segfaults instead of raising.
+pytestmark = requires_native_window
+
 
 @pytest.fixture()
 def info_panel(qapp: QApplication) -> InfoPanel:

--- a/tests/ui/test_slice_mode.py
+++ b/tests/ui/test_slice_mode.py
@@ -7,6 +7,13 @@ from meshscope.ui.main_window import MainWindow
 from meshscope.ui.slice_overlay import SliceOverlayWidget
 from meshscope.ui.viewport_widget import ViewportWidget
 
+from ._native_window import requires_native_window
+
+# These tests construct MainWindow/ViewportWidget, which build a VTK render
+# window from QWidget.winId(). That handle is not dereferenceable under the
+# offscreen QPA plugin, so the process segfaults instead of raising.
+pytestmark = requires_native_window
+
 
 @pytest.fixture()
 def qapp() -> QApplication:

--- a/tests/ui/test_viewport.py
+++ b/tests/ui/test_viewport.py
@@ -7,6 +7,13 @@ from PySide6.QtWidgets import QApplication
 
 from meshscope.ui.viewport_widget import ViewportWidget
 
+from ._native_window import requires_native_window
+
+# These tests construct MainWindow/ViewportWidget, which build a VTK render
+# window from QWidget.winId(). That handle is not dereferenceable under the
+# offscreen QPA plugin, so the process segfaults instead of raising.
+pytestmark = requires_native_window
+
 
 @pytest.fixture()
 def widget(qapp: QApplication) -> ViewportWidget:

--- a/tests/unit/test_mesh_exporter.py
+++ b/tests/unit/test_mesh_exporter.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from meshscope.core.exceptions import MeshExportError
 from meshscope.core.mesh_data import BoundingBox, MeshData, MeshMetadata
@@ -95,6 +97,14 @@ class TestExportMeshAtomicWrite:
         assert len(files) == 1
         assert files[0].name == "output.stl"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "needs POSIX permissions: on Windows os.chmod is ignored for "
+            "directories, so the directory stays writable and the export "
+            "correctly succeeds"
+        ),
+    )
     def test_export_to_readonly_dir_raises(self, tmp_path: Path) -> None:
         readonly_dir = tmp_path / "readonly"
         readonly_dir.mkdir()

--- a/tests/unit/test_mesh_validation.py
+++ b/tests/unit/test_mesh_validation.py
@@ -1,6 +1,7 @@
 """Tests for file path validation and format detection."""
 
 import stat
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -54,6 +55,14 @@ class TestValidatePath:
             with pytest.raises(FileTooLargeError, match="500MB"):
                 validate_path(f)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "needs POSIX permissions: on Windows os.chmod only toggles the "
+            "read-only attribute, so the file stays readable and validate_path "
+            "correctly does not raise"
+        ),
+    )
     def test_file_not_readable(self, tmp_path: Path) -> None:
         f = tmp_path / "secret.stl"
         f.write_bytes(b"\x00" * 100)


### PR DESCRIPTION
The `test` job has **never passed on main** — red since the first run on 2026-04-08. `pytest` died with `Fatal Python error: Segmentation fault` during fixture setup, before a single UI test executed.

## Root cause

Traced to the exact frame:

```
QVTKRenderWindowInteractor.__init__  (line 379)
  self._RenderWindow.SetWindowInfo(str(int(WId)))
<- src/meshscope/ui/viewport_widget.py:39   QVTKRenderWindowInteractor(self)
<- src/meshscope/ui/main_window.py:91       ViewportWidget(self)
<- tests/ui/test_file_loading.py:19         `window` fixture
```

`viewport_widget` imports `vtkmodules.vtkRenderingOpenGL2` (added in `60190f1` so the app renders). That registers VTK's OpenGL2 object factory, which swaps the render-window class. Confirmed by direct measurement:

| | `vtkRenderWindow()` returns |
|---|---|
| without the OpenGL2 import | `vtkRenderWindow` (generic; `SetWindowInfo` is inert) |
| with the OpenGL2 import | **`vtkCocoaRenderWindow`** (casts the handle to `NSView*`) |

`SetWindowInfo()` casts its argument to a native pointer (`NSView*` / `HWND` / `Window`) and dereferences it. Under `QT_QPA_PLATFORM=offscreen` there is no native window, so `QWidget.winId()` returns a synthetic counter — measured as `1`, `2`, `4`. Dereferencing that kills the process.

It is a **hard crash, not a Python exception**, so `try`/`except` cannot catch it. `ViewportWidget`'s "shows an error message if OpenGL fails" path never gets a chance to run.

## Fix

Two commits, each independently verifiable.

**1. Don't run render-window tests where there is no window.** `tests/ui/_native_window.py` detects whether Qt can supply a dereferenceable handle (handle-less QPA plugins; on Linux, no `DISPLAY`/`WAYLAND_DISPLAY`). The five modules that construct `MainWindow`/`ViewportWidget` are marked with it. `test_info_panel.py` needs no render window and keeps running headless.

**2. Give Linux a real display so those tests actually run.** Skipping alone would mean the 184 render-window tests never execute in CI — which has been their status all along. Linux runners get `xvfb` plus Mesa `llvmpipe` software GL (VTK 9 needs GL ≥ 3.2; llvmpipe provides 4.5), and run the **full 549-test suite**. macOS/Windows have no VTK-usable GL, stay headless, and skip those tests cleanly.

Also pins `shell: bash` on both run steps: `pytest || [ $? -eq 5 ]` is bash syntax, and the Windows runner defaults to `pwsh`, where it is not valid — a latent bug in the same step.

## Verification

Reproduced and fixed locally on macOS before pushing:

| Scenario | Before | After |
|---|---|---|
| `QT_QPA_PLATFORM=offscreen pytest` | `Fatal Python error: Segmentation fault` | **365 passed, 184 skipped**, exit 0 |
| `pytest` (real display) | 549 passed | **549 passed** |

`ruff check src/ tests/` passes. CI confirms the Linux xvfb path, which cannot be exercised on a macOS workstation.

## Coverage impact

The 232 UI tests go from *never executed in CI* to **executed on every Linux run**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)